### PR TITLE
Store heading anchor in custom data

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -26,6 +26,10 @@ typedef struct {
   size_t size;
 } AnchorLocationArray;
 
+typedef struct {
+  char *anchor;
+} HeadingInfo;
+
 void init_anchor_location_array(AnchorLocationArray *a, size_t initialSize);
 void insert_anchor_location_array(AnchorLocationArray *a,
                                   AnchorLocation *element);

--- a/test/example/e001/expected.html
+++ b/test/example/e001/expected.html
@@ -1,1 +1,3 @@
-<h1><span id='id'>Header</span></h1>
+<h1 id='id'>
+Header
+</h1>

--- a/test/example/e003/expected.html
+++ b/test/example/e003/expected.html
@@ -1,1 +1,3 @@
-<h1><code>head</code><span id='id'></span></h1>
+<h1 id='id'>
+<code>head</code>
+</h1>


### PR DESCRIPTION
This is slightly cleaner design (separating parsing from rendering) at the cost of more code.

Unfortunately, it is not really possible to hook into the parser without forking cmark-gfm (the extensibility related functions are all internal) so we still need to do this by AST transformations.

Also, the fact that we use custom block element means that the HTML output is split over multiple lines.
