### PR TITLE
build: update Nixpkgs to 26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694334959,
-        "narHash": "sha256-gzFNaGF9en0TbS305YP/O2iFTLEbFgGPrv7bdCCq3xo=",
-        "owner": "ryantm",
+        "lastModified": 1780145889,
+        "narHash": "sha256-md0zn0RnwNvPyASas1yG5YUuwQ4ALA6ucL50l0DvqCo=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6ef87607d8bfc0c8ab75d3f841b294d1781f9e2c",
+        "rev": "8c50a710ddca43d7a530fb805ad55bde8d0141c5",
         "type": "github"
       },
       "original": {
-        "owner": "ryantm",
-        "ref": "minman",
+        "owner": "NixOS",
+        "ref": "26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   description = "Minimal Markdown Documentation";
-  inputs.nixpkgs.url = "github:ryantm/nixpkgs/minman";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/26.05";
   inputs.systems.url = "github:nix-systems/default";
   outputs = {
     self,

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -10,8 +10,4 @@ in rec {
   mmdoc-docs = pkgs.callPackage ./mmdoc-docs.nix {inherit mmdoc;};
   devShell = pkgs.callPackage ./devShell.nix {};
   fmt = pkgs.callPackage ./fmt.nix {};
-  nixpkgs-manual-mmdoc = pkgs.callPackage "${nixpkgs}/pkgs/tools/nix/nixpkgs-manual-mmdoc" {
-
-    inherit mmdoc;
-  };
 }

--- a/pkgs/devShell.nix
+++ b/pkgs/devShell.nix
@@ -4,7 +4,7 @@
   writeScriptBin,
   mkShell,
   cmark-gfm,
-  fastJson,
+  libfastjson,
   libzip,
   pkg-config,
   meson,
@@ -50,7 +50,7 @@ in
     name = "mmdoc";
     buildInputs = [
       cmark-gfm
-      fastJson
+      libfastjson
       libzip.dev
     ];
 
@@ -65,9 +65,9 @@ in
         cppcheck
 
         doc-build
-        doc-watch
       ]
       ++ lib.optionals (!stdenv.isDarwin) [
+        doc-watch
         valgrind
       ];
   }

--- a/pkgs/mmdoc.nix
+++ b/pkgs/mmdoc.nix
@@ -3,7 +3,7 @@
   stdenv,
   cmark-gfm,
   xxd,
-  fastJson,
+  libfastjson,
   libzip,
   self,
   ninja,
@@ -19,9 +19,9 @@ with lib;
 
     nativeBuildInputs = [ninja meson pkg-config xxd];
 
-    buildInputs = [cmark-gfm fastJson libzip];
+    buildInputs = [cmark-gfm libfastjson libzip];
 
-    doCheck = stdenv.isx86_64;
+    doCheck = true;
 
     meta = {
       description = "Minimal Markdown Documentation";

--- a/src/asset.c
+++ b/src/asset.c
@@ -71,11 +71,9 @@ int asset_write_to_dir_fuse_basic_min_js(char *dir) {
                             ___src_asset_fuse_basic_min_js_len);
 }
 int asset_write_to_file_fuse_basic_min_js(FILE *file) {
-  return asset_write_to_file(file,
-                            ___src_asset_fuse_basic_min_js,
-                            ___src_asset_fuse_basic_min_js_len);
+  return asset_write_to_file(file, ___src_asset_fuse_basic_min_js,
+                             ___src_asset_fuse_basic_min_js_len);
 }
-
 
 extern unsigned char ___src_asset_a11y_light_css[];
 extern unsigned int ___src_asset_a11y_light_css_len;

--- a/src/multi.c
+++ b/src/multi.c
@@ -23,15 +23,14 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
         "    <meta charset='utf-8'>\n"
         "    <meta name='viewport' content='width=device-width, "
         "initial-scale=1.0'>\n"
-        "    <meta name='description' content='", page_file);
+        "    <meta name='description' content='",
+        page_file);
   fputs(anchor_location->title, page_file);
   fputs("'>\n"
         "    <link rel='icon' href='favicon.svg'>\n",
         page_file);
   html_css(page_file);
-  fputs(
-        "    <title>",
-        page_file);
+  fputs("    <title>", page_file);
   fputs(anchor_location->title, page_file);
   fputs(" | ", page_file);
   fputs(inputs.project_name, page_file);
@@ -50,12 +49,13 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
   fputs("    <button type='button' class='search-toggle "
         "emoji'>🔍&#xFE0E;</button>",
         page_file);
-  fputs(
-      "    <button type='button' class='theme-toggle emoji'>🌘&#xFE0E;</button>",
-      page_file);
+  fputs("    <button type='button' class='theme-toggle "
+        "emoji'>🌘&#xFE0E;</button>",
+        page_file);
 
   if (prev_anchor_location != NULL) {
-    fputs("    <a id='chapter-previous-button' class='chapter-previous' href='", page_file);
+    fputs("    <a id='chapter-previous-button' class='chapter-previous' href='",
+          page_file);
     fputs(prev_anchor_location->multipage_url, page_file);
     fputs("' title='", page_file);
     fputs(prev_anchor_location->title, page_file);
@@ -64,7 +64,8 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
     fputs("    <span>&nbsp;</span>", page_file);
 
   if (next_anchor_location != NULL) {
-    fputs("    <a id='chapter-next-button' class='chapter-next' href='", page_file);
+    fputs("    <a id='chapter-next-button' class='chapter-next' href='",
+          page_file);
     fputs(next_anchor_location->multipage_url, page_file);
     fputs("' title='", page_file);
     fputs(next_anchor_location->title, page_file);
@@ -98,8 +99,7 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
   fputs("    </nav>\n", page_file);
   fputs("      </section>\n", page_file);
 
-  fputs("<script defer='true' src='search_index.js'></script>\n",
-        page_file);
+  fputs("<script defer='true' src='search_index.js'></script>\n", page_file);
 
   html_js(page_file);
   html_search_js(page_file);

--- a/src/single.c
+++ b/src/single.c
@@ -59,9 +59,9 @@ int mmdoc_single(Inputs inputs, AnchorLocationArray toc_anchor_locations) {
   fputs("    <nav class='nav-top'>\n", index_file);
   fputs("      <label for='sidebar-checkbox' class='sidebar-toggle'>≡</label>",
         index_file);
-  fputs(
-      "    <button type='button' class='theme-toggle emoji'>🌘&#xFE0E;</button>",
-      index_file);
+  fputs("    <button type='button' class='theme-toggle "
+        "emoji'>🌘&#xFE0E;</button>",
+        index_file);
   fputs("    </nav>\n"
         "    </div>\n",
         index_file);


### PR DESCRIPTION
## Summary
- switch the flake from the unavailable personal Nixpkgs fork to the official NixOS 26.05 tag
- use the current libfastjson package name
- keep the Linux-only doc watcher out of Darwin development shells
- run the test suite on every supported architecture

## Verification
- nix build -L
- nix develop --command meson test -C build-normal --print-errorlogs
- nix develop --command sh -c "meson --version && pkg-config --modversion libcmark-gfm libfastjson libzip"