### PR TITLE
fix: grow zero-capacity arrays before insertion

### DIFF
--- a/src/types.c
+++ b/src/types.c
@@ -12,7 +12,7 @@ void init_anchor_location_array(AnchorLocationArray *a, size_t initialSize) {
 void insert_anchor_location_array(AnchorLocationArray *a,
                                   AnchorLocation *element) {
   if (a->used == a->size) {
-    a->size *= 2;
+    a->size = a->size == 0 ? 1 : a->size * 2;
     a->array = realloc(a->array, a->size * sizeof(*a->array));
   }
   a->array[a->used] = *element;
@@ -33,7 +33,7 @@ void init_array(Array *a, size_t initialSize) {
 
 void insert_array(Array *a, char *element) {
   if (a->used == a->size) {
-    a->size *= 2;
+    a->size = a->size == 0 ? 1 : a->size * 2;
     a->array = realloc(a->array, a->size * sizeof *a->array);
   }
   a->array[a->used] = malloc(strlen(element) + 1);

--- a/test/test.c
+++ b/test/test.c
@@ -264,6 +264,33 @@ int test_copy_nested_image() {
   return 0;
 }
 
+int test_zero_capacity_arrays() {
+  Array array;
+  init_array(&array, 0);
+  insert_array(&array, "value");
+  if (array.used != 1 || array.size != 1 ||
+      strcmp(array.array[0], "value") != 0) {
+    printf("zero-capacity string array test failed\n");
+    free_array(&array);
+    return 1;
+  }
+  free_array(&array);
+
+  AnchorLocationArray anchor_locations;
+  init_anchor_location_array(&anchor_locations, 0);
+  AnchorLocation anchor_location = {.anchor = "#anchor"};
+  insert_anchor_location_array(&anchor_locations, &anchor_location);
+  if (anchor_locations.used != 1 || anchor_locations.size != 1 ||
+      strcmp(anchor_locations.array[0].anchor, "#anchor") != 0) {
+    printf("zero-capacity anchor-location array test failed\n");
+    free_anchor_location_array(&anchor_locations);
+    return 1;
+  }
+  free_anchor_location_array(&anchor_locations);
+  printf("zero-capacity array tests passed\n");
+  return 0;
+}
+
 int main(int argc, char *argv[]) {
   int num_failed = 0;
   int num_tests = 0;
@@ -288,6 +315,8 @@ int main(int argc, char *argv[]) {
   num_failed += test_render("e009");
   num_tests++;
   num_failed += test_copy_nested_image();
+  num_tests++;
+  num_failed += test_zero_capacity_arrays();
   num_tests++;
 
   printf("%d of %d tests passed.", num_tests - num_failed, num_tests);


### PR DESCRIPTION
## Problem
Both dynamic-array insert functions double their capacity when full. For arrays initialized with capacity 0, doubling leaves the capacity at 0, `realloc` still requests zero bytes, and the following write targets `array[0]` outside any allocated object.

## Fix
Grow empty arrays to capacity 1 before returning to geometric doubling, for both string arrays and anchor-location arrays.

## Verification
- added regression coverage for inserting into both zero-capacity array types
- `meson test -C build-normal --print-errorlogs` passes (11/11 tests)