### PR TITLE
fix: copy images from nested directories

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: CC0-1.0 */
 #include "inputs.h"
+#include "mkdir_p.h"
 #include "types.h"
 #include <dirent.h>
 #include <errno.h>
@@ -73,9 +74,8 @@ int copy_imgs(Inputs inputs) {
   mmdoc_img_files(&img_files, inputs.src);
 
   for (int i = 0; i < img_files.used; i++) {
-    int ch;
     char *source_path = img_files.array[i];
-    FILE *source = fopen(source_path, "r");
+    FILE *source = fopen(source_path, "rb");
 
     if (NULL == source) {
       printf("Failed to open file %s for reading: %s\n", source_path,
@@ -85,17 +85,16 @@ int copy_imgs(Inputs inputs) {
     }
 
     char *rel_path = source_path + strlen(inputs.src);
-    char *multi_path =
-        malloc(strlen(inputs.out_multi) + 1 + strlen(rel_path) + 1);
+    char *multi_path = malloc(strlen(inputs.out_multi) + strlen(rel_path) + 1);
     if (NULL == multi_path) {
       printf("Failed to allocate memory at %s line %d\n", __FILE__, __LINE__);
       fclose(source);
       free_array(&img_files);
       return -1;
     }
-    sprintf(multi_path, "%s/%s", inputs.out_multi, rel_path);
+    sprintf(multi_path, "%s%s", inputs.out_multi, rel_path);
     char *single_path =
-        malloc(strlen(inputs.out_single) + 1 + strlen(rel_path) + 1);
+        malloc(strlen(inputs.out_single) + strlen(rel_path) + 1);
     if (NULL == single_path) {
       printf("Failed to allocate memory at %s line %d\n", __FILE__, __LINE__);
       free(multi_path);
@@ -104,9 +103,34 @@ int copy_imgs(Inputs inputs) {
       return -1;
     }
 
-    sprintf(single_path, "%s/%s", inputs.out_single, rel_path);
+    sprintf(single_path, "%s%s", inputs.out_single, rel_path);
 
-    FILE *multi = fopen(multi_path, "w");
+    char *multi_file_name = strrchr(multi_path, '/');
+    char *single_file_name = strrchr(single_path, '/');
+    if (multi_file_name == NULL || single_file_name == NULL) {
+      printf("Failed to determine image output directories\n");
+      free(single_path);
+      free(multi_path);
+      fclose(source);
+      free_array(&img_files);
+      return -1;
+    }
+    *multi_file_name = '\0';
+    *single_file_name = '\0';
+    int mkdir_failed = mkdir_p(multi_path) != 0 || mkdir_p(single_path) != 0;
+    *multi_file_name = '/';
+    *single_file_name = '/';
+    if (mkdir_failed) {
+      printf("Failed to create image output directories: %s\n",
+             strerror(errno));
+      free(single_path);
+      free(multi_path);
+      fclose(source);
+      free_array(&img_files);
+      return -1;
+    }
+
+    FILE *multi = fopen(multi_path, "wb");
     if (multi == NULL) {
       printf("Failed to open file %s for writing: %s\n", multi_path,
              strerror(errno));
@@ -116,42 +140,58 @@ int copy_imgs(Inputs inputs) {
       free_array(&img_files);
       return -1;
     }
-    free(multi_path);
 
-    FILE *single = fopen(single_path, "w");
+    FILE *single = fopen(single_path, "wb");
     if (single == NULL) {
       printf("Failed to open file %s for writing: %s\n", single_path,
              strerror(errno));
       fclose(multi);
       fclose(source);
+      free(single_path);
+      free(multi_path);
       free_array(&img_files);
       return -1;
     }
-    free(single_path);
 
-    while ((ch = fgetc(source)) != EOF) {
-      int ret;
-      ret = fputc(ch, multi);
-      if (ret != ch) {
+    unsigned char buffer[64 * 1024];
+    size_t bytes_read;
+    while ((bytes_read = fread(buffer, 1, sizeof(buffer), source)) > 0) {
+      if (fwrite(buffer, 1, bytes_read, multi) != bytes_read) {
         fclose(single);
         fclose(multi);
         fclose(source);
+        free(single_path);
+        free(multi_path);
         free_array(&img_files);
         return -1;
       }
-      ret = fputc(ch, single);
-      if (ret != ch) {
+      if (fwrite(buffer, 1, bytes_read, single) != bytes_read) {
         fclose(single);
         fclose(multi);
         fclose(source);
+        free(single_path);
+        free(multi_path);
         free_array(&img_files);
         return -1;
       }
+    }
+
+    if (ferror(source)) {
+      printf("Failed to read file %s: %s\n", source_path, strerror(errno));
+      fclose(single);
+      fclose(multi);
+      fclose(source);
+      free(single_path);
+      free(multi_path);
+      free_array(&img_files);
+      return -1;
     }
 
     fclose(single);
     fclose(multi);
     fclose(source);
+    free(single_path);
+    free(multi_path);
   }
   free_array(&img_files);
   return 0;

--- a/src/files.h
+++ b/src/files.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: CC0-1.0 */
 #pragma once
 #include "inputs.h"
+#include "types.h"
 
 void mmdoc_md_files(Array *md_files, char *base_path);
 void mmdoc_img_files(Array *img_files, char *base_path);

--- a/test/test.c
+++ b/test/test.c
@@ -1,6 +1,9 @@
 /* SPDX-License-Identifier: CC0-1.0 */
+#include "../src/files.h"
+#include "../src/mkdir_p.h"
 #include "../src/render.h"
 #include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -197,6 +200,70 @@ int test_title(char *example, char *expected_title) {
   return 0;
 }
 
+int file_matches_bytes(char *path, const unsigned char *expected,
+                       size_t expected_size) {
+  unsigned char got[16];
+  if (expected_size > sizeof(got))
+    return 0;
+
+  FILE *file = fopen(path, "rb");
+  if (file == NULL)
+    return 0;
+  size_t got_size = fread(got, 1, sizeof(got), file);
+  int close_result = fclose(file);
+  return close_result == 0 && got_size == expected_size &&
+         memcmp(got, expected, expected_size) == 0;
+}
+
+int test_copy_nested_image() {
+  char root[] = "/tmp/mmdoc-image-test-XXXXXX";
+  if (mkdtemp(root) == NULL)
+    return 1;
+
+  char src_dir[PATH_MAX];
+  char source_dir[PATH_MAX];
+  char source_path[PATH_MAX];
+  char multi_dir[PATH_MAX];
+  char multi_path[PATH_MAX];
+  char single_dir[PATH_MAX];
+  char single_path[PATH_MAX];
+  snprintf(src_dir, sizeof(src_dir), "%s/src", root);
+  snprintf(source_dir, sizeof(source_dir), "%s/assets/icons", src_dir);
+  snprintf(source_path, sizeof(source_path), "%s/pixel.png", source_dir);
+  snprintf(multi_dir, sizeof(multi_dir), "%s/out/multi", root);
+  snprintf(multi_path, sizeof(multi_path), "%s/assets/icons/pixel.png",
+           multi_dir);
+  snprintf(single_dir, sizeof(single_dir), "%s/out/single", root);
+  snprintf(single_path, sizeof(single_path), "%s/assets/icons/pixel.png",
+           single_dir);
+
+  if (mkdir_p(source_dir) != 0)
+    return 1;
+
+  const unsigned char image[] = {0, 1, 2, 0xff};
+  FILE *source = fopen(source_path, "wb");
+  if (source == NULL)
+    return 1;
+  int write_failed = fwrite(image, 1, sizeof(image), source) != sizeof(image);
+  if (fclose(source) != 0 || write_failed)
+    return 1;
+
+  Inputs inputs = {
+      .src = src_dir,
+      .out_multi = multi_dir,
+      .out_single = single_dir,
+  };
+  if (copy_imgs(inputs) != 0)
+    return 1;
+
+  if (!file_matches_bytes(multi_path, image, sizeof(image)) ||
+      !file_matches_bytes(single_path, image, sizeof(image)))
+    return 1;
+
+  printf("nested image copy test passed\n");
+  return 0;
+}
+
 int main(int argc, char *argv[]) {
   int num_failed = 0;
   int num_tests = 0;
@@ -219,6 +286,8 @@ int main(int argc, char *argv[]) {
   num_failed += test_render("e008");
   num_tests++;
   num_failed += test_render("e009");
+  num_tests++;
+  num_failed += test_copy_nested_image();
   num_tests++;
 
   printf("%d of %d tests passed.", num_tests - num_failed, num_tests);


### PR DESCRIPTION
## Problem
`copy_imgs` writes each discovered image directly below the existing output roots. When an image is in a nested source directory that has no corresponding Markdown output directory, `fopen` fails because the parent directory was never created.

The same loop also copies every byte through two `fputc` calls, which adds avoidable per-byte overhead for large image assets.

## Fix
- create each image destination parent recursively
- preserve the source-relative path without an extra slash
- use binary modes and a 64 KiB `fread`/`fwrite` buffer
- make files.h self-contained

## Verification
- added a regression test with a binary PNG fixture under assets/icons
- verifies byte-identical copies in both multi and single outputs
- `meson test -C build-normal --print-errorlogs` passes (11/11 tests)

Temporarily based on #53 so CI uses the repaired Nix flake; retarget to main after #53 merges.