### PR TITLE
perf: write embedded assets in one buffered call

### DIFF
--- a/src/asset.c
+++ b/src/asset.c
@@ -16,12 +16,9 @@ extern int errno;
 
 static int asset_write_to_file(FILE *file, unsigned char *asset_array,
                                unsigned int asset_array_length) {
-  for (int i = 0; i < asset_array_length; i++) {
-    int ret = fputc(asset_array[i], file);
-    if (ret == EOF) {
-      printf("Failed to write to file: %s\n", strerror(errno));
-      return -1;
-    }
+  if (fwrite(asset_array, 1, asset_array_length, file) != asset_array_length) {
+    printf("Failed to write to file: %s\n", strerror(errno));
+    return -1;
   }
   return 0;
 }


### PR DESCRIPTION
## Motivation
Every generated page embeds roughly 1 MiB of CSS and JavaScript, dominated by highlight.pack.js. The writer currently sends that data through `fputc` one byte at a time, resulting in about 8 million function calls for the bundled seven-page documentation site.

## Change
Replace the per-byte loop with one checked `fwrite` call. Output and error behavior remain equivalent.

## Verification
- full unit suite passes (10/10 tests)
- generated trees before and after compare byte-for-byte identical with `diff -rq`
- bundled-doc generation CPU time drops from 0.10s to below `/usr/bin/time` 0.01s resolution on this machine

This replaces #56, which was accidentally merged into the already-merged #53 branch rather than main.