### PR TITLE
ci: replace retired macOS 11 runner

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
           source: '.'
           extensions: 'h,c,cpp,hpp'
   test-darwin:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
       - uses: cachix/install-nix-action@v31


### PR DESCRIPTION
## Problem
The test workflow targets `macos-11`, whose GitHub-hosted runner image was retired on June 28, 2024. The macOS check therefore remains queued indefinitely and never validates the Darwin build.

## Fix
Use the rolling `macos-latest` label, which GitHub recommends for architecture-agnostic workflows.

## Verification
The Linux job remains green; this PR exists to make the Darwin job schedulable again.