### PR TITLE
fix: initialize page controls directly

### DIFF
--- a/src/asset/mmdoc.js
+++ b/src/asset/mmdoc.js
@@ -1,6 +1,4 @@
 //// Sidebar
-setTimeout(() => {
-
 function getSidebarClosed() {
   return (localStorage.getItem('sidebar-closed') ?? 'false') === 'true'
 }
@@ -23,7 +21,7 @@ function setupSaveSidebar() {
   el.addEventListener('change', saveSidebar)
 }
 
-window.addEventListener('DOMContentLoaded', setupSaveSidebar)
+setupSaveSidebar()
 
 if (getSidebarClosed())
   showSidebar()
@@ -73,7 +71,7 @@ function setupToggleTheme() {
   })
 }
 
-window.addEventListener('DOMContentLoaded', setupToggleTheme)
+setupToggleTheme()
 
 if (getSelectedTheme() === 'dark')
   setDarkTheme();
@@ -105,4 +103,3 @@ window.addEventListener('keydown', (event) => {
   }
 
 })
-},0);


### PR DESCRIPTION
## Summary

- remove the zero-delay timer around page UI initialization
- attach sidebar and theme handlers immediately after their markup
- avoid racing DOMContentLoaded on cached or fast page loads

## Performance

The generated script is three lines smaller. Initialization remains at the bottom of the document and only performs the existing lightweight DOM and local-storage operations.

## Verification

- nix build -L
- generated both single-page and multi-page documentation
- confirmed both outputs call setupSaveSidebar and setupToggleTheme directly