### PR TITLE
fix: reject overlong anchors safely

### DIFF
--- a/src/anchors.c
+++ b/src/anchors.c
@@ -1,19 +1,22 @@
 /* SPDX-License-Identifier: CC0-1.0 */
-#include "inputs.h"
+#include "anchors.h"
 #include "mkdir_p.h"
 #include "render.h"
-#include "types.h"
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 enum ref_parse_state { NONE, L, REF };
 
-void mmdoc_anchors(Array *md_anchors, char *path) {
+int mmdoc_anchors(Array *md_anchors, char *path) {
   char ref[1024];
-  int refpos = 0;
-  FILE *file;
-  file = fopen(path, "r");
+  size_t refpos = 0;
+  FILE *file = fopen(path, "r");
+  if (file == NULL) {
+    fprintf(stderr, "Error opening %s: %s\n", path, strerror(errno));
+    return 1;
+  }
   int c;
   enum ref_parse_state state = NONE;
 
@@ -33,6 +36,12 @@ void mmdoc_anchors(Array *md_anchors, char *path) {
     }
     if (state == REF && (c == '\n' || c == '\r')) {
     } else if (state == REF && c != '}') {
+      if (refpos >= sizeof(ref) - 1) {
+        fprintf(stderr, "Anchor in %s exceeds %zu bytes.\n", path,
+                sizeof(ref) - 1);
+        fclose(file);
+        return 1;
+      }
       ref[refpos] = c;
       refpos += 1;
       continue;
@@ -45,6 +54,7 @@ void mmdoc_anchors(Array *md_anchors, char *path) {
     continue;
   }
   fclose(file);
+  return 0;
 }
 
 int mmdoc_anchors_locations(AnchorLocationArray *anchor_locations,
@@ -57,7 +67,10 @@ int mmdoc_anchors_locations(AnchorLocationArray *anchor_locations,
   for (int i = 0; i < md_files->used; i++) {
     Array anchors;
     init_array(&anchors, 500);
-    mmdoc_anchors(&anchors, md_files->array[i]);
+    if (mmdoc_anchors(&anchors, md_files->array[i]) != 0) {
+      free_array(&anchors);
+      return -1;
+    }
     for (int j = 0; j < anchors.used; j++) {
       AnchorLocation *al = malloc(sizeof *al);
       al->anchor = anchors.array[j];

--- a/src/anchors.h
+++ b/src/anchors.h
@@ -2,6 +2,7 @@
 #include "inputs.h"
 #include "types.h"
 
+int mmdoc_anchors(Array *md_anchors, char *path);
 int mmdoc_anchors_locations(AnchorLocationArray *anchor_locations,
                             Array *md_files, Array *toc_refs, Inputs inputs);
 int mmdoc_anchors_find_toc_anchors(AnchorLocationArray *toc_anchor_locations,

--- a/src/refs.c
+++ b/src/refs.c
@@ -1,18 +1,23 @@
 /* SPDX-License-Identifier: CC0-1.0 */
-#include "types.h"
+#include "refs.h"
+#include <errno.h>
 #include <stdio.h>
+#include <string.h>
 
 enum ref_parse_state { NONE, L, REF };
 
 int mmdoc_refs(Array *md_refs, char *path) {
   char ref[1024];
-  int refpos = 0;
-  FILE *file;
-  file = fopen(path, "r");
+  size_t refpos = 0;
+  init_array(md_refs, 500);
+
+  FILE *file = fopen(path, "r");
+  if (file == NULL) {
+    fprintf(stderr, "Error opening %s: %s\n", path, strerror(errno));
+    return 1;
+  }
   int c;
   enum ref_parse_state state = NONE;
-
-  init_array(md_refs, 500);
 
   while (1) {
     c = fgetc(file);
@@ -30,6 +35,12 @@ int mmdoc_refs(Array *md_refs, char *path) {
     }
     if (state == REF && (c == '\n' || c == '\r')) {
     } else if (state == REF && c != ')') {
+      if (refpos >= sizeof(ref) - 1) {
+        fprintf(stderr, "Anchor reference in %s exceeds %zu bytes.\n", path,
+                sizeof(ref) - 1);
+        fclose(file);
+        return 1;
+      }
       ref[refpos] = c;
       refpos += 1;
       continue;

--- a/src/refs.h
+++ b/src/refs.h
@@ -1,2 +1,6 @@
 /* SPDX-License-Identifier: CC0-1.0 */
+#pragma once
+
+#include "types.h"
+
 int mmdoc_refs(Array *md_refs, char *path);

--- a/test/test.c
+++ b/test/test.c
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: CC0-1.0 */
+#include "../src/anchors.h"
 #include "../src/files.h"
 #include "../src/mkdir_p.h"
+#include "../src/refs.h"
 #include "../src/render.h"
 #include <errno.h>
 #include <limits.h>
@@ -291,6 +293,53 @@ int test_zero_capacity_arrays() {
   return 0;
 }
 
+int write_overlong_id(char *path, const char *prefix, const char *suffix) {
+  int fd = mkstemps(path, 5);
+  if (fd == -1)
+    return 1;
+
+  FILE *file = fdopen(fd, "w");
+  if (file == NULL) {
+    close(fd);
+    return 1;
+  }
+
+  int failed = fputs(prefix, file) == EOF;
+  for (int i = 0; i < 1024 && !failed; i++)
+    failed = fputc('a', file) == EOF;
+  if (!failed)
+    failed = fputs(suffix, file) == EOF;
+  return fclose(file) != 0 || failed;
+}
+
+int test_reject_overlong_ids() {
+  char ref_path[] = "/tmp/mmdoc-ref-XXXXXX.html";
+  if (write_overlong_id(ref_path, "[page](#", ")") != 0)
+    return 1;
+
+  Array refs;
+  int refs_result = mmdoc_refs(&refs, ref_path);
+  unlink(ref_path);
+  free_array(&refs);
+
+  char anchor_path[] = "/tmp/mmdoc-anchor-XXXXXX.html";
+  if (write_overlong_id(anchor_path, "{#", "}") != 0)
+    return 1;
+
+  Array anchors;
+  init_array(&anchors, 1);
+  int anchors_result = mmdoc_anchors(&anchors, anchor_path);
+  unlink(anchor_path);
+  free_array(&anchors);
+
+  if (refs_result == 0 || anchors_result == 0) {
+    printf("overlong anchor rejection test failed\n");
+    return 1;
+  }
+  printf("overlong anchors rejected\n");
+  return 0;
+}
+
 int main(int argc, char *argv[]) {
   int num_failed = 0;
   int num_tests = 0;
@@ -317,6 +366,8 @@ int main(int argc, char *argv[]) {
   num_failed += test_copy_nested_image();
   num_tests++;
   num_failed += test_zero_capacity_arrays();
+  num_tests++;
+  num_failed += test_reject_overlong_ids();
   num_tests++;
 
   printf("%d of %d tests passed.", num_tests - num_failed, num_tests);


### PR DESCRIPTION
## Summary

- prevent stack writes past the fixed anchor buffers
- reject anchor IDs and TOC references longer than 1,023 bytes with an error
- handle source-file open failures instead of dereferencing a null FILE pointer
- propagate anchor scanner errors to the caller
- add regression coverage for both overlong input forms

## Performance

The scanners retain fixed stack buffers and add only one bounds comparison per anchor byte. No dynamic buffer allocation is introduced.

## Verification

- nix build -L
- clang-format verification on all changed C files