### PR TITLE
fix: release search index JSON objects

### DIFF
--- a/src/render.c
+++ b/src/render.c
@@ -386,6 +386,7 @@ void insert_search_index(FILE *search_index_path, const char *text,
   fjson_object_object_add(obj, "text", obj_text);
   fputs(fjson_object_to_json_string(obj), search_index_path);
   fputs("\n,", search_index_path);
+  fjson_object_put(obj);
 }
 
 /**


### PR DESCRIPTION
## Summary

Release each search-index JSON root object after its serialized form has been written. The root owns the URL, title, and text child objects, so this frees the entire per-page JSON tree.

Generated output is unchanged.

## Verification

- nix build -L
- clang-format verification