### PR TITLE
Refresh documentation UI

### DIFF
--- a/src/asset/mmdoc.css
+++ b/src/asset/mmdoc.css
@@ -1,249 +1,293 @@
 :root {
-  --light_background: white;
-  --light_foreground: black;
-  --light_lightest-gray: #f8f8f8;
-  --light_light-gray: lightgray;
-  --light_gray: gray;
-  --light_orange: #FF9636;
-  --light_yellow: #FFCD58;
-  --light_green: #DAD870;
-  --light_red: #FF5C4D;
-  --light_link: black;
+  --light_background: #fbfcfe;
+  --light_foreground: #1f2937;
+  --light_surface: #ffffff;
+  --light_surface-muted: #f3f6fa;
+  --light_border: #dce3eb;
+  --light_muted: #64748b;
+  --light_accent: #2563eb;
+  --light_accent-soft: #eaf2ff;
+  --light_code: #f6f8fa;
+  --light_green: #eaf7ef;
+  --light_orange: #fff4df;
+  --light_yellow: #fff9d9;
+  --light_red: #ffebea;
 
-  --dark_background: #2b2b2b;
-  --dark_foreground: #F5F5F5;
-  --dark_light-gray: gray;
-  --dark_lightest-gray: #202020;
-  --dark_gray: lightgray;
-  --dark_orange: #7c3b00;
-  --dark_yellow: #896000;
-  --dark_green: #69671b;
-  --dark_red: #850b00;
-  --dark_link: white;
+  --dark_background: #101620;
+  --dark_foreground: #e7edf5;
+  --dark_surface: #17202d;
+  --dark_surface-muted: #1c2736;
+  --dark_border: #334155;
+  --dark_muted: #9aa9bc;
+  --dark_accent: #83b4ff;
+  --dark_accent-soft: #1d3557;
+  --dark_code: #131c28;
+  --dark_green: #18382c;
+  --dark_orange: #49331b;
+  --dark_yellow: #403817;
+  --dark_red: #472526;
+
+  --background: var(--light_background);
+  --foreground: var(--light_foreground);
+  --surface: var(--light_surface);
+  --surface-muted: var(--light_surface-muted);
+  --border: var(--light_border);
+  --muted: var(--light_muted);
+  --accent: var(--light_accent);
+  --accent-soft: var(--light_accent-soft);
+  --code-background: var(--light_code);
+  --green: var(--light_green);
+  --orange: var(--light_orange);
+  --yellow: var(--light_yellow);
+  --red: var(--light_red);
+  --topbar-height: 58px;
+  --content-width: 76ch;
+  color: var(--foreground);
+  background: var(--background);
+  color-scheme: light;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --background: var(--dark_background);
     --foreground: var(--dark_foreground);
-    --light-gray: var(--dark_light-gray);
-    --lightest-gray: var(--dark_lightest-gray);
-    --gray: var(--light_gray);
+    --surface: var(--dark_surface);
+    --surface-muted: var(--dark_surface-muted);
+    --border: var(--dark_border);
+    --muted: var(--dark_muted);
+    --accent: var(--dark_accent);
+    --accent-soft: var(--dark_accent-soft);
+    --code-background: var(--dark_code);
+    --green: var(--dark_green);
     --orange: var(--dark_orange);
     --yellow: var(--dark_yellow);
-    --green: var(--dark_green);
     --red: var(--dark_red);
-    --link: var(--dark_link);
+    color-scheme: dark;
   }
 }
 
 :root.dark-theme {
   --background: var(--dark_background);
   --foreground: var(--dark_foreground);
-  --light-gray: var(--dark_light-gray);
-  --lightest-gray: var(--dark_lightest-gray);
-  --gray: var(--light_gray);
+  --surface: var(--dark_surface);
+  --surface-muted: var(--dark_surface-muted);
+  --border: var(--dark_border);
+  --muted: var(--dark_muted);
+  --accent: var(--dark_accent);
+  --accent-soft: var(--dark_accent-soft);
+  --code-background: var(--dark_code);
+  --green: var(--dark_green);
   --orange: var(--dark_orange);
   --yellow: var(--dark_yellow);
-  --green: var(--dark_green);
   --red: var(--dark_red);
-  --link: var(--dark_link);
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    --background: var(--light_background);
-    --foreground: var(--light_foreground);
-    --light-gray: var(--light_light-gray);
-    --lightest-gray: var(--light_lightest-gray);
-    --gray: var(--dark_gray);
-    --orange: var(--light_orange);
-    --yellow: var(--light_yellow);
-    --green: var(--light_green);
-    --red: var(--light_red);
-    --link: var(--light_link);
-  }
+  color-scheme: dark;
 }
 
 :root.light-theme {
   --background: var(--light_background);
   --foreground: var(--light_foreground);
-  --light-gray: var(--light_light-gray);
-  --lightest-gray: var(--light_lightest-gray);
-  --gray: var(--dark_gray);
+  --surface: var(--light_surface);
+  --surface-muted: var(--light_surface-muted);
+  --border: var(--light_border);
+  --muted: var(--light_muted);
+  --accent: var(--light_accent);
+  --accent-soft: var(--light_accent-soft);
+  --code-background: var(--light_code);
+  --green: var(--light_green);
   --orange: var(--light_orange);
   --yellow: var(--light_yellow);
-  --green: var(--light_green);
   --red: var(--light_red);
-  --link: var(--light_link);
+  color-scheme: light;
 }
 
-:root {
-  --topbar-height: 50px;
-  color: var(--foreground);
-  background-color: var(--background);
-}
-
-a {
-  text-decoration-color: var(--light-gray);
-  color: var(--foreground);
-}
-
-input {
-  color: var(--foreground);
-  background-color: var(--background);
+* {
+  box-sizing: border-box;
 }
 
 html, body {
   overflow: hidden;
-  height: 100vh;
   width: 100vw;
+  height: 100vh;
   margin: 0;
   padding: 0;
+  background: var(--background);
+}
 
-  line-height: 1.45;
-  font-family: "Open Sans", sans-serif;
-  background-color: var(--background);
+body {
+  color: var(--foreground);
+  font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  font-size: 16px;
+  line-height: 1.65;
+  text-rendering: optimizeLegibility;
+}
+
+::selection {
+  color: var(--foreground);
+  background: var(--accent-soft);
+}
+
+a {
+  color: var(--accent);
+  text-decoration-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  text-underline-offset: 0.18em;
+}
+
+a:hover {
+  text-decoration-color: currentColor;
+}
+
+:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 2px;
+}
+
+button, input {
+  color: var(--foreground);
+  font: inherit;
 }
 
 .body {
   position: fixed;
-  top: 0;
-  margin: 0;
-
-  height: 100%;
-  width: 100%;
-
+  inset: 0;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
-}
-
-.body {
   grid-template-areas:
-      "navtop navtop"
-      "search search"
-      "sidebar main";
-  grid-template-rows: var(--topbar-height) min-content auto;
-}
-.nav-top {
-  border-bottom: 1px solid var(--light-gray);
-}
-
-@media only screen and (max-width: 600px) {
-  .body {
-    grid-template-areas:
-        "sidebar main"
-        "navtop navtop"
-        "search search";
-    grid-template-rows: auto var(--topbar-height) min-content;
-  }
-  .nav-top {
-    border-top: 1px solid var(--light-gray);
-  }
-}
-
-input:checked + .body {
-  grid-template-columns: auto minmax(0, 1fr);
+    "navtop navtop"
+    "sidebar main";
+  grid-template-rows: var(--topbar-height) minmax(0, 1fr);
 }
 
 input:checked + .body > nav.sidebar {
   display: none;
 }
 
-@media (max-width: 600px) {
-  input:checked + .body > nav.sidebar {
-    display: block;
-  }
-  input:not(:checked) + .body > nav.sidebar {
-    display: none;
-  }
-}
-
-nav.sidebar {
-  overflow: auto;
-  grid-area: sidebar;
-  max-width: 100ch;
-  overflow: auto;
-  padding: 5px;
-  padding-right: 20px;
-  border-right: 1px solid var(--light-gray);
-  background-color: var(--lightest-gray);
-}
-
-nav ul ul {
-  padding-left: 15px;
-  list-style-type: none;
-}
-
-nav ul {
-  padding-left: 0px;
-  list-style-type: none;
-}
-
-/* .nav-chapter-previous:hover, .nav-chapter-next:hover { */
-/*   color: var(--gray); */
-/* } */
-
-.nav-chapter-previous {
-  float: left;
-}
-
-.nav-chapter-next {
-  float: right;
-  right: 0;
-}
-
 .nav-top-container {
+  z-index: 3;
   grid-area: navtop;
   height: var(--topbar-height);
-  background-color: var(--lightest-gray);
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+  box-shadow: 0 1px 8px rgb(15 23 42 / 6%);
 }
 
 .nav-top {
   display: grid;
-  grid-template-columns:
-      var(--topbar-height)
-      var(--topbar-height)
-      var(--topbar-height)
-      var(--topbar-height)
-      var(--topbar-height);
-  height: var(--topbar-height);
-  line-height: var(--topbar-height);
+  grid-template-columns: repeat(5, 42px);
+  gap: 5px;
+  align-items: center;
+  height: 100%;
+  padding: 7px 12px;
   overflow: hidden;
-  grid-column-gap: 10px;
-  border-bottom: 1px solid var(--light-gray);
 }
 
 .nav-top button, .nav-top a, .nav-top label {
-    line-height: 50px;
-    text-align: center;
-    text-decoration: none;
-    color: var(--foreground);
-    margin: 0;
-    font-family: monospace;
-    font-size: 50px;
-    border: none;
-    background-color: var(--lightest-gray);
-}
-
-.nav-top button.emoji, .nav-top a.emoji {
-    font-size: 30px;
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 9px;
+  appearance: none;
+  color: var(--muted);
+  background: transparent;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 26px;
+  line-height: 1;
+  text-align: center;
+  text-decoration: none;
+  transition: color 120ms ease, background-color 120ms ease;
 }
 
 .nav-top button:hover, .nav-top a:hover, .nav-top label:hover {
-  color: var(--gray);
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.sidebar-toggle, .search-toggle, .theme-toggle,
+.chapter-previous, .chapter-next {
+  position: relative;
+  font-size: 0 !important;
 }
 
 .sidebar-toggle, button.search-toggle, button.theme-toggle {
   cursor: pointer;
 }
 
+.sidebar-toggle::before, .search-toggle::before, .search-toggle::after,
+.theme-toggle::before, .chapter-previous::before, .chapter-next::before {
+  position: absolute;
+  content: "";
+}
+
+.sidebar-toggle::before {
+  top: 22px;
+  left: 12px;
+  width: 18px;
+  height: 2px;
+  border-radius: 2px;
+  background: currentColor;
+  box-shadow: 0 -6px currentColor, 0 6px currentColor;
+}
+
+.search-toggle::before {
+  top: 13px;
+  left: 12px;
+  width: 14px;
+  height: 14px;
+  border: 2px solid currentColor;
+  border-radius: 50%;
+}
+
+.search-toggle::after {
+  top: 26px;
+  left: 23px;
+  width: 7px;
+  height: 2px;
+  border-radius: 2px;
+  background: currentColor;
+  transform: rotate(45deg);
+  transform-origin: left center;
+}
+
+.theme-toggle::before {
+  top: 12px;
+  left: 12px;
+  width: 18px;
+  height: 18px;
+  border: 2px solid currentColor;
+  border-radius: 50%;
+  background: linear-gradient(90deg, currentColor 50%, transparent 50%);
+}
+
+.chapter-previous::before, .chapter-next::before {
+  top: 50%;
+  left: 50%;
+  width: 12px;
+  height: 12px;
+  margin: -6px 0 0 -6px;
+  border: solid currentColor;
+  border-width: 0 2px 2px 0;
+}
+
+.chapter-previous::before {
+  transform: rotate(135deg);
+}
+
+.chapter-next::before {
+  transform: rotate(-45deg);
+}
+
 .nav-search {
-  grid-area: search;
-  padding: 5px;
-  margin-left: auto;
-  margin-right: auto;
-  max-width: 80ch;
+  z-index: 2;
+  flex: 0 0 auto;
+  width: min(100%, var(--content-width));
+  margin: 0 auto;
+  padding: 12px 2rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
 }
 
 .search-visible nav.nav-search {
@@ -252,123 +296,298 @@ nav ul {
 
 #search {
   width: 100%;
-  font-size: 20px;
+  padding: 10px 13px;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  color: var(--foreground);
+  background: var(--surface);
+  box-shadow: 0 1px 2px rgb(15 23 42 / 5%);
+  font-size: 1rem;
+}
+
+#search:focus {
+  border-color: var(--accent);
 }
 
 #search-results {
-  overflow-y: auto;
   max-height: calc(60vh - var(--topbar-height));
+  overflow-y: auto;
 }
 
 #search-results ol {
-  padding-bottom: 1em;
-  border-bottom: 1px solid var(--light-gray);
+  margin: 0;
+  padding: 0.8rem 0 1rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+nav.sidebar {
+  grid-area: sidebar;
+  width: clamp(15rem, 23vw, 19rem);
+  padding: 1.6rem 1rem 3rem;
+  overflow: auto;
+  border-right: 1px solid var(--border);
+  background: var(--surface-muted);
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+nav.sidebar > :first-child {
+  margin-top: 0;
+}
+
+nav.sidebar h1, nav.sidebar h2 {
+  margin: 0 0 1rem;
+  padding: 0 0.65rem;
+  color: var(--foreground);
+  font-size: 0.78rem;
+  font-weight: 750;
+  letter-spacing: 0.09em;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+nav ul {
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+}
+
+nav ul ul {
+  margin-left: 0.7rem;
+  padding-left: 0.55rem;
+  border-left: 1px solid var(--border);
+}
+
+nav.sidebar li + li {
+  margin-top: 0.15rem;
+}
+
+nav.sidebar a {
+  display: block;
+  padding: 0.42rem 0.65rem;
+  border-radius: 7px;
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.35;
+  text-decoration: none;
+  transition: color 120ms ease, background-color 120ms ease;
+}
+
+nav.sidebar a:hover {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.nav-chapter-previous {
+  float: left;
+}
+
+.nav-chapter-next {
+  float: right;
 }
 
 section#main {
   grid-area: main;
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  flex-direction: column;
+}
+
+.main-scroll {
+  min-height: 0;
+  flex: 1 1 auto;
   overflow: auto;
+  scroll-behavior: smooth;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
 }
 
 main {
-  max-width: min(100vw, 80ch);
-  padding: 0em 1em 20em 1em;
-  margin-left: auto;
-  margin-right: auto;
+  width: min(100%, var(--content-width));
+  margin: 0 auto;
+  padding: 3rem 2rem 20rem;
 }
 
-main .admonition {
-  border-radius: 6px;
-  padding: 0.5em 1em 0.5em 1em;
-  margin: calc(1ex / 0.32) 0 0 0;
-  background-color: var(--green);
-}
-
-main .attention, main .caution, main .warning {
-  background-color: var(--orange);
-}
-
-main .danger, main .error {
-  background-color: var(--red);
-}
-
-main .important, main .note {
-  background-color: var(--yellow);
-}
-
-main table, main th, main td {
-  border: 2px solid var(--gray);
-  border-collapse: collapse;
-}
-
-main th, main td {
-  padding: 0.75em;
-}
-
-main h1:first-child, nav.sidebar > h1:first-child {
-  margin-top: 0px;
-  padding-top: 1rem;
-}
-
-main .admonition h3 {
-  margin-top: 0;
+main :is(h1, h2, h3, h4, h5, h6) {
+  color: var(--foreground);
+  font-weight: 720;
+  letter-spacing: -0.018em;
+  scroll-margin-top: 1.5rem;
 }
 
 main :is(h1, h2, h3, h4, h5, h6) a {
+  color: inherit;
   text-decoration: none;
 }
 
+main :is(h1, h2, h3, h4, h5, h6) a:hover {
+  color: var(--accent);
+}
+
 main h1 {
-    font-size: 2.5rem;
-    line-height: calc(1ex / 0.42);
-    margin-top: calc(1ex / 0.42);
+  margin: 0 0 1.3rem;
+  font-size: clamp(2.25rem, 5vw, 3.15rem);
+  line-height: 1.08;
 }
 
 main h2 {
-    font-size: 2rem;
-    line-height: calc(1ex / 0.42);
-    margin-top: calc(1ex / 0.42);
+  margin: 3.2rem 0 1rem;
+  padding-bottom: 0.45rem;
+  border-bottom: 1px solid var(--border);
+  font-size: 1.8rem;
+  line-height: 1.25;
 }
 
 main h3 {
-    font-size: 1.75rem;
-    line-height: calc(1ex / 0.38);
-    margin-top: calc(1ex / 0.38);
+  margin: 2.4rem 0 0.75rem;
+  font-size: 1.38rem;
+  line-height: 1.3;
 }
 
 main h4 {
-    font-size: 1.5rem;
-    line-height: calc(1ex / 0.37);
-    margin-top: calc(1ex / 0.37);
+  margin: 2rem 0 0.65rem;
+  font-size: 1.1rem;
+  line-height: 1.4;
 }
 
-main p {
-  font-size: 1rem;
-  line-height: calc(1ex / 0.32);
-  margin: calc(1ex / 0.32) 0 0 0;
+main :is(p, ul, ol, dl, pre, table, blockquote) {
+  margin-top: 1.15rem;
+  margin-bottom: 0;
+}
+
+main :is(ul, ol) {
+  padding-left: 1.4rem;
+}
+
+main li + li {
+  margin-top: 0.3rem;
+}
+
+main li::marker {
+  color: var(--muted);
+}
+
+main hr {
+  margin: 2.8rem 0;
+  border: 0;
+  border-top: 1px solid var(--border);
+}
+
+main img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
 }
 
 main blockquote {
-  border-left: 5px solid var(--light-gray);
-  margin-left: 0px;
-  padding-left: 10px;
-  font-size: 20px;
+  margin-left: 0;
+  padding: 0.2rem 0 0.2rem 1rem;
+  border-left: 3px solid var(--accent);
+  color: var(--muted);
+  font-size: 1.05rem;
 }
 
-code, code.hljs {
-  display: inline;
+main blockquote > :first-child {
+  margin-top: 0;
+}
+
+main table {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  border-spacing: 0;
+  border-collapse: separate;
+}
+
+main th, main td {
+  padding: 0.65rem 0.85rem;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+
+main th {
+  background: var(--surface-muted);
+  font-weight: 650;
+}
+
+main tr > :last-child {
+  border-right: 0;
+}
+
+main tr:last-child > td {
+  border-bottom: 0;
+}
+
+main .admonition {
+  margin-top: 1.4rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid color-mix(in srgb, #238b57 35%, var(--border));
+  border-left: 4px solid #238b57;
+  border-radius: 8px;
+  background: var(--green);
+}
+
+main .attention, main .caution, main .warning {
+  border-color: color-mix(in srgb, #c77800 35%, var(--border));
+  border-left-color: #c77800;
+  background: var(--orange);
+}
+
+main .danger, main .error {
+  border-color: color-mix(in srgb, #d53b3b 35%, var(--border));
+  border-left-color: #d53b3b;
+  background: var(--red);
+}
+
+main .important, main .note {
+  border-color: color-mix(in srgb, #b28a00 35%, var(--border));
+  border-left-color: #b28a00;
+  background: var(--yellow);
+}
+
+main .admonition .title {
+  margin: 0 0 0.35rem;
+  font-size: 0.82rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+main .admonition > :last-child {
+  margin-bottom: 0;
+}
+
+code {
+  padding: 0.16em 0.36em;
+  border: 1px solid var(--border);
   border-radius: 5px;
-  padding: 2px;
-  background: var(--lightest-gray);
+  background: var(--code-background);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.88em;
+}
+
+.dark-theme .hljs, .light-theme .hljs {
+  background: var(--code-background);
+}
+
+pre {
+  position: relative;
 }
 
 pre code, pre code.hljs {
   display: block;
-  padding: 10px;
-  border-radius: 5px;
-  border-color: var(--light-gray);
-  border-style: solid;
-  border-width: 1px;
+  padding: 1rem 1.1rem;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 3%);
+  font-size: 0.86rem;
+  line-height: 1.65;
   scrollbar-width: thin;
 }
 
@@ -379,4 +598,75 @@ code.language-shell .hljs-meta,
 code.language-Console .hljs-meta,
 code.language-console .hljs-meta {
   user-select: none;
+}
+
+@media (max-width: 700px) {
+  :root {
+    --topbar-height: 56px;
+  }
+
+  .body {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "main"
+      "navtop";
+    grid-template-rows: minmax(0, 1fr) var(--topbar-height);
+  }
+
+  .nav-top-container {
+    border-top: 1px solid var(--border);
+    border-bottom: 0;
+    box-shadow: 0 -1px 8px rgb(15 23 42 / 8%);
+  }
+
+  .nav-top {
+    grid-template-columns: repeat(5, 42px);
+    justify-content: space-between;
+    padding: 6px 8px;
+  }
+
+  input:checked + .body > nav.sidebar {
+    display: block;
+  }
+
+  input:not(:checked) + .body > nav.sidebar {
+    display: none;
+  }
+
+  .search-visible input:checked + .body > nav.sidebar {
+    display: none;
+  }
+
+  nav.sidebar {
+    z-index: 2;
+    grid-area: main;
+    width: 100%;
+    padding: 1.5rem 1rem 4rem;
+    border-right: 0;
+  }
+
+  .nav-search {
+    width: 100%;
+    padding: 10px 1.25rem;
+  }
+
+  main {
+    padding: 2.25rem 1.25rem 8rem;
+  }
+
+  main h1 {
+    font-size: 2.25rem;
+  }
+
+  main h2 {
+    margin-top: 2.6rem;
+    font-size: 1.55rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/src/multi.c
+++ b/src/multi.c
@@ -75,19 +75,19 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
 
   fputs("    </nav>\n", page_file);
   fputs("    </div>\n", page_file);
-  fputs("    <nav class='nav-search' style='display:none;'>\n", page_file);
-  fputs("        <input type='search' id='search' placeholder='Search'>\n"
-        "        <div id='search-results'></div>\n",
-        page_file);
-  fputs("    </nav>\n", page_file);
-
   fputs("    <nav class='sidebar'>\n", page_file);
   int has_code_block = mmdoc_render_part(
       inputs.toc_path, page_file, RENDER_TYPE_MULTIPAGE, anchor_location,
       anchor_locations, anchor_location->multipage_url, NULL);
   fputs("    </nav>\n", page_file);
-  fputs("      <section id='main'>\n", page_file);
-  fputs("      <main>\n", page_file);
+  fputs("    <section id='main'>\n", page_file);
+  fputs("      <nav class='nav-search' style='display:none;'>\n", page_file);
+  fputs("        <input type='search' id='search' placeholder='Search'>\n"
+        "        <div id='search-results'></div>\n",
+        page_file);
+  fputs("      </nav>\n", page_file);
+  fputs("      <div class='main-scroll'>\n", page_file);
+  fputs("        <main>\n", page_file);
 
   if (anchor_location->file_path != NULL)
     has_code_block |= mmdoc_render_part(
@@ -95,10 +95,9 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
         anchor_location, anchor_locations, anchor_location->multipage_url,
         search_index_file);
 
-  fputs("      </main>\n", page_file);
-  fputs("    <nav class='sidebar2'>\n", page_file);
-  fputs("    </nav>\n", page_file);
-  fputs("      </section>\n", page_file);
+  fputs("        </main>\n", page_file);
+  fputs("      </div>\n", page_file);
+  fputs("    </section>\n", page_file);
 
   fputs("<script defer='true' src='search_index.js'></script>\n", page_file);
 

--- a/src/single.c
+++ b/src/single.c
@@ -72,7 +72,8 @@ int mmdoc_single(Inputs inputs, AnchorLocationArray toc_anchor_locations) {
                         toc_anchor_locations, "/", NULL);
   fputs("    </nav>\n", index_file);
   fputs("    <section id='main'>\n", index_file);
-  fputs("      <main>\n", index_file);
+  fputs("      <div class='main-scroll'>\n", index_file);
+  fputs("        <main>\n", index_file);
 
   for (int i = 0; i < toc_anchor_locations.used; i++) {
     AnchorLocationArray empty_anchor_locations;
@@ -84,6 +85,7 @@ int mmdoc_single(Inputs inputs, AnchorLocationArray toc_anchor_locations) {
   }
 
   fputs("        </main>\n"
+        "      </div>\n"
         "      </section>\n"
         "    </div>\n",
         index_file);


### PR DESCRIPTION
## Summary

- refresh the light and dark color systems, typography, spacing, navigation, and content components
- replace browser-dependent toolbar glyph rendering with consistently sized CSS icons
- keep the sidebar full-height while aligning search with an independently scrolling main-content column
- preserve the mobile bottom toolbar and coordinate search with the full-width mobile sidebar

## Bundle size

- adds no imports, external CSS, images, libraries, or runtime dependencies
- increases the embedded stylesheet from 1.84 KB to 3.26 KB gzipped

## Validation

- nix develop -c meson test -C build-normal --print-errorlogs
- nix build .#mmdoc-docs -L
- generated and inspected both multi-page and single-page output
- git diff --check and C formatting checks