### PR TITLE
Highlight the current page in the sidebar

### DIFF
--- a/src/asset/mmdoc.css
+++ b/src/asset/mmdoc.css
@@ -378,6 +378,13 @@ nav.sidebar a:hover {
   background: var(--accent-soft);
 }
 
+nav.sidebar a[aria-current="page"] {
+  color: var(--accent);
+  background: var(--accent-soft);
+  box-shadow: inset 3px 0 var(--accent);
+  font-weight: 700;
+}
+
 .nav-chapter-previous {
   float: left;
 }

--- a/src/asset/mmdoc.js
+++ b/src/asset/mmdoc.js
@@ -28,6 +28,59 @@ if (getSidebarClosed())
 else
   hideSidebar()
 
+function normalizedPagePath(pathname) {
+  const withoutIndex = pathname.replace(/\/index\.html?$/i, '')
+  return withoutIndex.replace(/\/$/, '') || '/'
+}
+
+function scrollSidebarToLink(sidebar, link) {
+  window.requestAnimationFrame(() => {
+    const sidebarRect = sidebar.getBoundingClientRect()
+    if (sidebarRect.height === 0)
+      return
+
+    const linkRect = link.getBoundingClientRect()
+    const offset = linkRect.top + linkRect.height / 2 -
+      (sidebarRect.top + sidebarRect.height / 2)
+
+    sidebar.scrollTop += offset
+  })
+}
+
+function showCurrentPageInSidebar() {
+  const sidebar = document.querySelector('nav.sidebar')
+  if (sidebar === null)
+    return
+
+  const currentPath = normalizedPagePath(window.location.pathname)
+  const samePageLinks = Array.from(sidebar.querySelectorAll('a[href]')).filter(
+    link => {
+      const url = new URL(link.href, window.location.href)
+      return url.origin === window.location.origin &&
+        normalizedPagePath(url.pathname) === currentPath
+    })
+
+  if (samePageLinks.length === 0)
+    return
+
+  const matchingHashLink = samePageLinks.find(link => {
+    const url = new URL(link.href, window.location.href)
+    return url.hash !== '' && url.hash === window.location.hash
+  })
+  const currentPageLink = matchingHashLink ?? samePageLinks[0]
+
+  sidebar.querySelectorAll('a[aria-current="page"]').forEach(link => {
+    link.removeAttribute('aria-current')
+  })
+  currentPageLink.setAttribute('aria-current', 'page')
+  scrollSidebarToLink(sidebar, currentPageLink)
+}
+
+showCurrentPageInSidebar()
+window.addEventListener('hashchange', showCurrentPageInSidebar)
+document.getElementById('sidebar-checkbox').addEventListener(
+  'change', showCurrentPageInSidebar)
+
 //// Theme
 
 // Returns 'light' or 'dark'


### PR DESCRIPTION
## Summary

- mark the current sidebar link with `aria-current="page"`
- highlight the active page with the existing accent palette
- center the current item in long sidebars on load, hash navigation, and sidebar opening
- normalize trailing slashes and `index.html` when matching page URLs

## Testing

- `nix develop -c meson test -C build-normal --print-errorlogs`
- `nix develop -c meson compile -C build-normal`
- rebuilt `mmdoc-docs` and verified the new code from the localhost server