### PR TITLE
Improve sidebar hierarchy spacing

### DIFF
--- a/src/asset/mmdoc.css
+++ b/src/asset/mmdoc.css
@@ -334,7 +334,6 @@ nav.sidebar > :first-child {
 }
 
 nav.sidebar h1, nav.sidebar h2 {
-  margin: 0 0 1rem;
   padding: 0 0.65rem;
   color: var(--foreground);
   font-size: 0.78rem;
@@ -342,6 +341,22 @@ nav.sidebar h1, nav.sidebar h2 {
   letter-spacing: 0.09em;
   line-height: 1.4;
   text-transform: uppercase;
+}
+
+nav.sidebar h1 {
+  margin: 0 0 0.2rem;
+}
+
+nav.sidebar h1 + p {
+  margin: 0 0 1rem;
+  padding: 0 0.65rem;
+  color: var(--muted);
+  font-size: 0.84rem;
+  line-height: 1.4;
+}
+
+nav.sidebar h2 {
+  margin: 1.4rem 0 0.35rem;
 }
 
 nav ul {


### PR DESCRIPTION
## Summary

- align the sidebar title, version text, section headings, and top-level links on one left edge
- keep the title and version visually grouped
- add space before section headings and reduce the space after them so each heading belongs to the links it introduces
- style the title subtitle/version explicitly instead of relying on browser paragraph defaults

## Testing

- nix develop -c meson test -C build-normal --print-errorlogs
- nix build .#mmdoc-docs -L
- verified the updated stylesheet is embedded in both single-page and multi-page outputs