### PR TITLE
Preserve anchors in chapter navigation

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: CC0-1.0 */
+#include "multi.h"
 #include "asset.h"
 #include "html.h"
-#include "inputs.h"
 #include "render.h"
 #include <stdlib.h>
 #include <string.h>
@@ -57,6 +57,7 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
     fputs("    <a id='chapter-previous-button' class='chapter-previous' href='",
           page_file);
     fputs(prev_anchor_location->multipage_url, page_file);
+    fputs(prev_anchor_location->anchor, page_file);
     fputs("' title='", page_file);
     fputs(prev_anchor_location->title, page_file);
     fputs("'>&lt;</a>\n", page_file);
@@ -67,6 +68,7 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
     fputs("    <a id='chapter-next-button' class='chapter-next' href='",
           page_file);
     fputs(next_anchor_location->multipage_url, page_file);
+    fputs(next_anchor_location->anchor, page_file);
     fputs("' title='", page_file);
     fputs(next_anchor_location->title, page_file);
     fputs("'>&gt;</a>\n", page_file);

--- a/src/multi.h
+++ b/src/multi.h
@@ -1,6 +1,13 @@
 /* SPDX-License-Identifier: CC0-1.0 */
 #pragma once
+#include <stdio.h>
+
+#include "inputs.h"
 #include "types.h"
 
+int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
+                     FILE *search_index_file, AnchorLocation *anchor_location,
+                     AnchorLocation *prev_anchor_location,
+                     AnchorLocation *next_anchor_location);
 int mmdoc_multi(Inputs inputs, AnchorLocationArray toc_anchor_locations,
                 AnchorLocationArray anchor_locations);

--- a/test/test.c
+++ b/test/test.c
@@ -2,6 +2,7 @@
 #include "../src/anchors.h"
 #include "../src/files.h"
 #include "../src/mkdir_p.h"
+#include "../src/multi.h"
 #include "../src/refs.h"
 #include "../src/render.h"
 #include <errno.h>
@@ -318,6 +319,93 @@ int test_zero_capacity_arrays() {
   return 0;
 }
 
+int file_contains(char *path, const char *expected) {
+  FILE *file = fopen(path, "r");
+  if (file == NULL)
+    return 0;
+
+  char *line = NULL;
+  size_t line_size = 0;
+  int found = 0;
+  while (getline(&line, &line_size, file) != -1) {
+    if (strstr(line, expected) != NULL) {
+      found = 1;
+      break;
+    }
+  }
+  free(line);
+  fclose(file);
+  return found;
+}
+
+int test_multipage_navigation_anchor() {
+  char root[] = "/tmp/mmdoc-navigation-test-XXXXXX";
+  if (mkdtemp(root) == NULL)
+    return 1;
+
+  char page_path[PATH_MAX];
+  char toc_path[PATH_MAX];
+  snprintf(page_path, sizeof(page_path), "%s/index.html", root);
+  snprintf(toc_path, sizeof(toc_path), "%s/toc.md", root);
+
+  FILE *toc_file = fopen(toc_path, "w");
+  if (toc_file == NULL)
+    return 1;
+  if (fclose(toc_file) != 0)
+    return 1;
+
+  FILE *search_index_file = tmpfile();
+  if (search_index_file == NULL)
+    return 1;
+
+  Inputs inputs = {
+      .project_name = "Nixpkgs",
+      .toc_path = toc_path,
+  };
+  AnchorLocation current = {
+      .file_path = NULL,
+      .multipage_output_file_path = page_path,
+      .multipage_base_href = "",
+      .multipage_url = "./",
+      .anchor = "#preface",
+      .title = "Preface",
+  };
+  AnchorLocation previous = {
+      .multipage_url = "./",
+      .anchor = "#preface",
+      .title = "Preface",
+  };
+  AnchorLocation next = {
+      .multipage_url = "preface/",
+      .anchor = "#overview-of-nixpkgs",
+      .title = "Overview of Nixpkgs",
+  };
+  AnchorLocationArray anchor_locations;
+  init_anchor_location_array(&anchor_locations, 0);
+
+  int render_result = mmdoc_multi_page(
+      inputs, anchor_locations, search_index_file, &current, &previous, &next);
+  int found_previous = file_contains(
+      page_path, "id='chapter-previous-button' class='chapter-previous' "
+                 "href='./#preface'");
+  int found_next =
+      file_contains(page_path, "id='chapter-next-button' class='chapter-next' "
+                               "href='preface/#overview-of-nixpkgs'");
+
+  free_anchor_location_array(&anchor_locations);
+  fclose(search_index_file);
+  unlink(page_path);
+  unlink(toc_path);
+  rmdir(root);
+
+  if (render_result != 0 || !found_previous || !found_next) {
+    printf("multipage navigation anchor test failed\n");
+    return 1;
+  }
+  printf("multipage navigation anchor test passed\n");
+  return 0;
+}
+
 int write_overlong_id(char *path, const char *prefix, const char *suffix) {
   int fd = mkstemps(path, 5);
   if (fd == -1)
@@ -399,6 +487,8 @@ int main(int argc, char *argv[]) {
   num_failed += test_copy_nested_image();
   num_tests++;
   num_failed += test_zero_capacity_arrays();
+  num_tests++;
+  num_failed += test_multipage_navigation_anchor();
   num_tests++;
   num_failed += test_reject_overlong_ids();
   num_tests++;


### PR DESCRIPTION
## Summary

- include destination anchors in previous and next chapter links
- make right-arrow navigation from the manual preface land on `preface/#overview-of-nixpkgs`
- add a regression test for both navigation directions

## Testing

- `nix develop -c meson test -C build-normal --print-errorlogs`
- `nix develop -c clang-format --dry-run --Werror src/multi.c src/multi.h test/test.c`
- `git diff --check`