### PR TITLE
Close the table of contents after mobile navigation

### DIFF
--- a/src/asset/mmdoc.js
+++ b/src/asset/mmdoc.js
@@ -21,7 +21,22 @@ function setupSaveSidebar() {
   el.addEventListener('change', saveSidebar)
 }
 
+function closeSidebarOnMobileNavigation() {
+  if (!window.matchMedia('(max-width: 700px)').matches)
+    return
+
+  hideSidebar()
+  saveSidebar()
+}
+
+function setupCloseSidebarOnMobileNavigation() {
+  Array.from(document.querySelectorAll('nav.sidebar a[href]')).forEach(link => {
+    link.addEventListener('click', closeSidebarOnMobileNavigation)
+  })
+}
+
 setupSaveSidebar()
+setupCloseSidebarOnMobileNavigation()
 
 if (getSidebarClosed())
   showSidebar()


### PR DESCRIPTION
## Summary

- close the table of contents after selecting a sidebar link on screens up to 700px wide
- persist the closed state across full-page navigation
- leave desktop sidebar behavior unchanged

## Testing

- `nix develop -c meson test -C build-normal --print-errorlogs`
- `nix develop -c meson compile -C build-normal`
- verified with headless Chrome that clicking a mobile sidebar link unchecks the sidebar and stores the closed state
- `git diff --check`