### PR TITLE
Share multipage assets and improve documentation accessibility

### DIFF
--- a/doc/features.md
+++ b/doc/features.md
@@ -4,3 +4,5 @@
 * Fast: written in C, using cmark a very fast Markdown parser/renderer.
 * The HTML documents have syntax highlighting via [highlight.js](https://highlightjs.org/).
 * The multi-page HTML documents have full-text search via [fuse.js](https://fusejs.io/).
+* The multi-page documents share cacheable style and script assets, while the single-page document is self-contained.
+* The generated interface includes keyboard-operable controls, a skip link, labelled navigation, and light and dark themes.

--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -29,11 +29,13 @@ doc
 └── usage.md
 ```
 
-and ouputs
+and outputs
 
 ```text
 out
 ├── multi
+│   ├── a11y-dark.css
+│   ├── a11y-light.css
 │   ├── development
 │   │   └── index.html
 │   ├── features
@@ -43,15 +45,16 @@ out
 │   ├── index.html
 │   ├── license
 │   │   └── index.html
-│   ├── minimal.css
-│   ├── mono-blue.css
+│   ├── mmdoc.css
+│   ├── mmdoc.js
+│   ├── mmdoc_search.js
 │   ├── search_index.js
-│   ├── search.js
 │   └── usage
 │       └── index.html
 └── single
-    ├── highlight.pack.js
-    ├── index.html
-    ├── minimal.css
-    └── mono-blue.css
+    └── index.html
 ```
+
+The multi-page output uses shared, cacheable assets. The single-page output
+embeds its styling and scripts in `index.html` so it remains portable as one
+file.

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -56,3 +56,12 @@ In order to be useful for Documentation, it uses several CommonMark extensions a
 
   : defintion 2
   ```
+
+## Generated interface
+
+The table of contents, search, and theme controls are available from the top
+navigation bar. Press `/` or <kbd>Control</kbd>/<kbd>Command</kbd>+<kbd>K</kbd>
+to open search, then use the up and down arrow keys to cycle through results.
+Outside interactive controls, the left and right arrow keys move between pages.
+A skip link appears when focused so keyboard users can move directly to the
+main content.

--- a/src/asset.c
+++ b/src/asset.c
@@ -59,6 +59,11 @@ int asset_write_to_file_highlight_pack_js(FILE *file) {
   return asset_write_to_file(file, ___src_asset_highlight_pack_js,
                              ___src_asset_highlight_pack_js_len);
 }
+int asset_write_to_dir_highlight_pack_js(char *dir) {
+  return asset_write_to_dir(dir, "highlight.pack.js",
+                            ___src_asset_highlight_pack_js,
+                            ___src_asset_highlight_pack_js_len);
+}
 
 extern unsigned char ___src_asset_fuse_basic_min_js[];
 extern unsigned int ___src_asset_fuse_basic_min_js_len;
@@ -67,16 +72,15 @@ int asset_write_to_dir_fuse_basic_min_js(char *dir) {
                             ___src_asset_fuse_basic_min_js,
                             ___src_asset_fuse_basic_min_js_len);
 }
-int asset_write_to_file_fuse_basic_min_js(FILE *file) {
-  return asset_write_to_file(file, ___src_asset_fuse_basic_min_js,
-                             ___src_asset_fuse_basic_min_js_len);
-}
-
 extern unsigned char ___src_asset_a11y_light_css[];
 extern unsigned int ___src_asset_a11y_light_css_len;
 int asset_write_to_file_a11y_light_css(FILE *file) {
   return asset_write_to_file(file, ___src_asset_a11y_light_css,
                              ___src_asset_a11y_light_css_len);
+}
+int asset_write_to_dir_a11y_light_css(char *dir) {
+  return asset_write_to_dir(dir, "a11y-light.css", ___src_asset_a11y_light_css,
+                            ___src_asset_a11y_light_css_len);
 }
 
 extern unsigned char ___src_asset_a11y_dark_css[];
@@ -85,12 +89,20 @@ int asset_write_to_file_a11y_dark_css(FILE *file) {
   return asset_write_to_file(file, ___src_asset_a11y_dark_css,
                              ___src_asset_a11y_dark_css_len);
 }
+int asset_write_to_dir_a11y_dark_css(char *dir) {
+  return asset_write_to_dir(dir, "a11y-dark.css", ___src_asset_a11y_dark_css,
+                            ___src_asset_a11y_dark_css_len);
+}
 
 extern unsigned char ___src_asset_mmdoc_css[];
 extern unsigned int ___src_asset_mmdoc_css_len;
 int asset_write_to_file_mmdoc_css(FILE *file) {
   return asset_write_to_file(file, ___src_asset_mmdoc_css,
                              ___src_asset_mmdoc_css_len);
+}
+int asset_write_to_dir_mmdoc_css(char *dir) {
+  return asset_write_to_dir(dir, "mmdoc.css", ___src_asset_mmdoc_css,
+                            ___src_asset_mmdoc_css_len);
 }
 
 extern unsigned char ___src_asset_mmdoc_js[];
@@ -99,10 +111,15 @@ int asset_write_to_file_mmdoc_js(FILE *file) {
   return asset_write_to_file(file, ___src_asset_mmdoc_js,
                              ___src_asset_mmdoc_js_len);
 }
+int asset_write_to_dir_mmdoc_js(char *dir) {
+  return asset_write_to_dir(dir, "mmdoc.js", ___src_asset_mmdoc_js,
+                            ___src_asset_mmdoc_js_len);
+}
 
 extern unsigned char ___src_asset_mmdoc_search_js[];
 extern unsigned int ___src_asset_mmdoc_search_js_len;
-int asset_write_to_file_mmdoc_search_js(FILE *file) {
-  return asset_write_to_file(file, ___src_asset_mmdoc_search_js,
-                             ___src_asset_mmdoc_search_js_len);
+int asset_write_to_dir_mmdoc_search_js(char *dir) {
+  return asset_write_to_dir(dir, "mmdoc_search.js",
+                            ___src_asset_mmdoc_search_js,
+                            ___src_asset_mmdoc_search_js_len);
 }

--- a/src/asset.h
+++ b/src/asset.h
@@ -4,11 +4,15 @@
 #include <stdio.h>
 
 int asset_write_to_dir_fuse_basic_min_js(char *dir);
+int asset_write_to_dir_highlight_pack_js(char *dir);
+int asset_write_to_dir_a11y_dark_css(char *dir);
+int asset_write_to_dir_a11y_light_css(char *dir);
+int asset_write_to_dir_mmdoc_css(char *dir);
+int asset_write_to_dir_mmdoc_js(char *dir);
+int asset_write_to_dir_mmdoc_search_js(char *dir);
 
-int asset_write_to_file_fuse_basic_min_js(FILE *file);
 int asset_write_to_file_a11y_dark_css(FILE *file);
 int asset_write_to_file_a11y_light_css(FILE *file);
 int asset_write_to_file_highlight_pack_js(FILE *file);
 int asset_write_to_file_mmdoc_css(FILE *file);
 int asset_write_to_file_mmdoc_js(FILE *file);
-int asset_write_to_file_mmdoc_search_js(FILE *file);

--- a/src/asset/mmdoc.css
+++ b/src/asset/mmdoc.css
@@ -143,6 +143,33 @@ a:hover {
   outline-offset: 2px;
 }
 
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 10;
+  top: 0.75rem;
+  left: 0.75rem;
+  padding: 0.55rem 0.8rem;
+  border-radius: 7px;
+  background: var(--surface);
+  box-shadow: 0 2px 12px rgb(15 23 42 / 18%);
+  transform: translateY(-200%);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
 button, input {
   color: var(--foreground);
   font: inherit;

--- a/src/asset/mmdoc.js
+++ b/src/asset/mmdoc.js
@@ -1,47 +1,57 @@
 //// Sidebar
+const sidebarMedia = window.matchMedia('(max-width: 700px)')
+
 function getSidebarClosed() {
   return (localStorage.getItem('sidebar-closed') ?? 'false') === 'true'
 }
 
-function showSidebar() {
-  document.getElementById('sidebar-checkbox').checked = true
+function isSidebarVisible() {
+  const checked = document.getElementById('sidebar-checkbox').checked
+  return sidebarMedia.matches ? checked : !checked
 }
 
-function hideSidebar() {
-  document.getElementById('sidebar-checkbox').checked = false
-}
-
-function saveSidebar() {
-  const sidebarClosed = document.getElementById('sidebar-checkbox').checked
-  localStorage.setItem('sidebar-closed', sidebarClosed)
-}
-
-function setupSaveSidebar() {
-  const el = document.getElementById('sidebar-checkbox')
-  el.addEventListener('change', saveSidebar)
-}
-
-function closeSidebarOnMobileNavigation() {
-  if (!window.matchMedia('(max-width: 700px)').matches)
-    return
-
-  hideSidebar()
-  saveSidebar()
-}
-
-function setupCloseSidebarOnMobileNavigation() {
-  Array.from(document.querySelectorAll('nav.sidebar a[href]')).forEach(link => {
-    link.addEventListener('click', closeSidebarOnMobileNavigation)
+function updateSidebarToggle(visible) {
+  document.querySelectorAll('.sidebar-toggle').forEach(button => {
+    button.setAttribute('aria-expanded', String(visible))
+    button.setAttribute(
+      'aria-label', visible ? 'Hide table of contents' : 'Show table of contents')
   })
 }
 
-setupSaveSidebar()
-setupCloseSidebarOnMobileNavigation()
+function setSidebarVisible(visible) {
+  document.getElementById('sidebar-checkbox').checked =
+    sidebarMedia.matches ? visible : !visible
+  updateSidebarToggle(visible)
+}
 
-if (getSidebarClosed())
-  showSidebar()
-else
-  hideSidebar()
+function toggleSidebar() {
+  setSidebarVisible(!isSidebarVisible())
+  if (!sidebarMedia.matches)
+    localStorage.setItem('sidebar-closed', String(!isSidebarVisible()))
+  showCurrentPageInSidebar()
+}
+
+function closeSidebarOnMobileNavigation() {
+  if (!sidebarMedia.matches)
+    return
+
+  setSidebarVisible(false)
+}
+
+function setupSidebar() {
+  document.querySelectorAll('.sidebar-toggle').forEach(button => {
+    button.addEventListener('click', toggleSidebar)
+  })
+  Array.from(document.querySelectorAll('nav.sidebar a[href]')).forEach(link => {
+    link.addEventListener('click', closeSidebarOnMobileNavigation)
+  })
+  sidebarMedia.addEventListener('change', event => {
+    setSidebarVisible(event.matches ? false : !getSidebarClosed())
+  })
+  setSidebarVisible(sidebarMedia.matches ? false : !getSidebarClosed())
+}
+
+setupSidebar()
 
 function normalizedPagePath(pathname) {
   const withoutIndex = pathname.replace(/\/index\.html?$/i, '')
@@ -93,8 +103,6 @@ function showCurrentPageInSidebar() {
 
 showCurrentPageInSidebar()
 window.addEventListener('hashchange', showCurrentPageInSidebar)
-document.getElementById('sidebar-checkbox').addEventListener(
-  'change', showCurrentPageInSidebar)
 
 //// Theme
 
@@ -126,11 +134,22 @@ function toggleTheme() {
 function setDarkTheme() {
   document.querySelector('html').classList.remove("light-theme")
   document.querySelector('html').classList.add("dark-theme")
+  updateThemeToggle('dark')
 }
 
 function setLightTheme() {
   document.querySelector('html').classList.remove("dark-theme")
   document.querySelector('html').classList.add("light-theme")
+  updateThemeToggle('light')
+}
+
+function updateThemeToggle(theme) {
+  const dark = theme === 'dark'
+  document.querySelectorAll('.theme-toggle').forEach(button => {
+    button.setAttribute('aria-pressed', String(dark))
+    button.setAttribute(
+      'aria-label', dark ? 'Switch to light theme' : 'Switch to dark theme')
+  })
 }
 
 function setupToggleTheme() {
@@ -156,18 +175,28 @@ window.addEventListener('load', (event) => {
   codeElems.forEach(e => e.classList.add('hljs'))
 })
 
-window.addEventListener('keydown', (event) => {
-  e = event || window.event;
+if (typeof hljs !== 'undefined')
+  hljs.highlightAll()
 
-  var button = null
-  if (e.key === 'ArrowLeft') {
+function isInteractiveTarget(target) {
+  return target.closest(
+    'a, button, input, select, textarea, [contenteditable="true"]') !== null
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.defaultPrevented || event.altKey || event.ctrlKey || event.metaKey ||
+      event.shiftKey || isInteractiveTarget(event.target))
+    return
+
+  let button = null
+  if (event.key === 'ArrowLeft') {
     button = document.getElementById('chapter-previous-button')
   }
-  else if (e.key === 'ArrowRight') {
+  else if (event.key === 'ArrowRight') {
     button = document.getElementById('chapter-next-button')
   }
   if (button !== null) {
+    event.preventDefault()
     button.click()
   }
-
 })

--- a/src/asset/mmdoc_search.js
+++ b/src/asset/mmdoc_search.js
@@ -2,28 +2,28 @@
 
 function setupSearch() {
   const fuse = new Fuse(corpus, { keys: ['title', 'text'], ignoreLocation: true, threshold: 0.01, minMatchCharLength: 3 })
-  let input = document.getElementById('search')
+  const input = document.getElementById('search')
+  const resultsElem = document.getElementById('search-results')
+  const statusElem = document.getElementById('search-status')
   let timeout = null
-  input.addEventListener('keyup', function (e) {
-    if (e.key === "Escape") {
-      toggleSearch()
-      return
-    }
+  input.addEventListener('input', function () {
     clearTimeout(timeout)
     timeout = setTimeout(function () {
-      let resultsElem = document.getElementById('search-results')
       resultsElem.innerHTML = ""
+      statusElem.textContent = ""
       if (input.value === "")
         return
-      let results = fuse.search(input.value)
-      var h2 = document.createElement('h2')
-      h2.appendChild(document.createTextNode(results.length + " search result(s)"))
+      const results = fuse.search(input.value)
+      const resultLabel = results.length === 1 ? 'search result' : 'search results'
+      statusElem.textContent = results.length + ' ' + resultLabel
+      const h2 = document.createElement('h2')
+      h2.appendChild(document.createTextNode(results.length + ' ' + resultLabel))
       resultsElem.appendChild(h2)
-      var ol = document.createElement('ol')
+      const ol = document.createElement('ol')
       resultsElem.appendChild(ol)
       results.forEach(function (result) {
-        var li = document.createElement('li')
-        var a = document.createElement('a')
+        const li = document.createElement('li')
+        const a = document.createElement('a')
         a.href = result.item.url
         a.appendChild(document.createTextNode(result.item.title))
         li.appendChild(a)
@@ -33,17 +33,83 @@ function setupSearch() {
   })
 }
 
-window.addEventListener('DOMContentLoaded', setupSearch)
+let searchPreviousFocus = null
+
+function moveSearchResultFocus(direction) {
+  const input = document.getElementById('search')
+  const links = Array.from(
+    document.querySelectorAll('#search-results a[href]'))
+  if (links.length === 0)
+    return
+
+  const currentIndex = links.indexOf(document.activeElement)
+  if (currentIndex === -1) {
+    links[direction > 0 ? 0 : links.length - 1].focus()
+    return
+  }
+
+  const nextIndex = currentIndex + direction
+  if (nextIndex < 0 || nextIndex >= links.length)
+    input.focus()
+  else
+    links[nextIndex].focus()
+}
+
+function setSearchVisible(visible) {
+  const root = document.querySelector('html')
+  const panel = document.getElementById('search-panel')
+  const input = document.getElementById('search')
+  root.classList.toggle('search-visible', visible)
+  panel.hidden = !visible
+  document.querySelectorAll('.search-toggle').forEach(button => {
+    button.setAttribute('aria-expanded', String(visible))
+    button.setAttribute('aria-label', visible ? 'Close search' : 'Open search')
+  })
+
+  if (visible) {
+    searchPreviousFocus = document.activeElement
+    if (typeof setSidebarVisible === 'function' && sidebarMedia.matches)
+      setSidebarVisible(false)
+    input.focus()
+    input.select()
+  } else if (searchPreviousFocus !== null) {
+    searchPreviousFocus.focus()
+    searchPreviousFocus = null
+  }
+}
 
 function toggleSearch() {
-  document.querySelector('html').classList.toggle("search-visible")
-  document.getElementById('search').select()
+  const visible = document.getElementById('search-panel').hidden
+  setSearchVisible(visible)
 }
 
 function setupToggleSearch() {
   Array.from(document.querySelectorAll('.search-toggle')).forEach(el => {
     el.addEventListener('click', toggleSearch)
   })
+  window.addEventListener('keydown', event => {
+    const target = event.target
+    const isTyping = target.closest(
+      'input, select, textarea, [contenteditable="true"]') !== null
+    const shortcut = event.key === '/' ||
+      ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k')
+    if (event.defaultPrevented || isTyping || !shortcut)
+      return
+    event.preventDefault()
+    setSearchVisible(true)
+  })
+  document.getElementById('search-panel').addEventListener('keydown', event => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      setSearchVisible(false)
+      return
+    }
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp')
+      return
+    event.preventDefault()
+    moveSearchResultFocus(event.key === 'ArrowDown' ? 1 : -1)
+  })
 }
 
-window.addEventListener('DOMContentLoaded', setupToggleSearch)
+setupSearch()
+setupToggleSearch()

--- a/src/html.c
+++ b/src/html.c
@@ -10,16 +10,6 @@ int html_js(FILE *file) {
   return 0;
 }
 
-int html_search_js(FILE *file) {
-  fputs("<script defer='true'>\n", file);
-  if (asset_write_to_file_fuse_basic_min_js(file) != 0)
-    return -1;
-  if (asset_write_to_file_mmdoc_search_js(file) != 0)
-    return -1;
-  fputs("</script>\n", file);
-  return 0;
-}
-
 int html_highlight_js(FILE *file) {
   fputs("<script>\n", file);
   if (asset_write_to_file_highlight_pack_js(file) != 0)

--- a/src/html.h
+++ b/src/html.h
@@ -6,4 +6,3 @@
 int html_css(FILE *file);
 int html_highlight_js(FILE *file);
 int html_js(FILE *file);
-int html_search_js(FILE *file);

--- a/src/multi.c
+++ b/src/multi.c
@@ -1,7 +1,6 @@
 /* SPDX-License-Identifier: CC0-1.0 */
 #include "multi.h"
 #include "asset.h"
-#include "html.h"
 #include "render.h"
 #include <stdlib.h>
 #include <string.h>
@@ -9,7 +8,8 @@
 int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
                      FILE *search_index_file, AnchorLocation *anchor_location,
                      AnchorLocation *prev_anchor_location,
-                     AnchorLocation *next_anchor_location) {
+                     AnchorLocation *next_anchor_location,
+                     int *has_code_blocks) {
   char *page_path = anchor_location->multipage_output_file_path;
   FILE *page_file;
   page_file = fopen(page_path, "w");
@@ -29,7 +29,10 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
   fputs("'>\n"
         "    <link rel='icon' href='favicon.svg'>\n",
         page_file);
-  html_css(page_file);
+  fputs("    <link rel='stylesheet' href='a11y-dark.css'>\n"
+        "    <link rel='stylesheet' href='a11y-light.css'>\n"
+        "    <link rel='stylesheet' href='mmdoc.css'>\n",
+        page_file);
   fputs("    <title>", page_file);
   fputs(anchor_location->title, page_file);
   fputs(" | ", page_file);
@@ -38,19 +41,26 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
         "  </head>\n"
         "  <body>\n",
         page_file);
-  fputs("  <input type='checkbox' id='sidebar-checkbox' style='display: "
-        "none;'/>\n",
+  fputs("  <a class='skip-link' href='#main-content'>Skip to main "
+        "content</a>\n"
+        "  <input type='checkbox' id='sidebar-checkbox' aria-hidden='true' "
+        "tabindex='-1' style='display: none;'>\n",
         page_file);
   fputs("  <div class='body'>\n", page_file);
   fputs("    <div class='nav-top-container'>\n", page_file);
-  fputs("    <nav class='nav-top'>\n", page_file);
-  fputs("      <label for='sidebar-checkbox' class='sidebar-toggle'>≡</label>",
+  fputs("    <nav class='nav-top' aria-label='Documentation controls'>\n",
+        page_file);
+  fputs("      <button type='button' class='sidebar-toggle' "
+        "aria-label='Toggle table of contents' aria-controls='sidebar' "
+        "aria-expanded='true'></button>",
         page_file);
   fputs("    <button type='button' class='search-toggle "
-        "emoji'>🔍&#xFE0E;</button>",
+        "emoji' aria-label='Open search' aria-controls='search-panel' "
+        "aria-expanded='false'>🔍&#xFE0E;</button>",
         page_file);
   fputs("    <button type='button' class='theme-toggle "
-        "emoji'>🌘&#xFE0E;</button>",
+        "emoji' aria-label='Switch to dark theme' "
+        "aria-pressed='false'>🌘&#xFE0E;</button>",
         page_file);
 
   if (prev_anchor_location != NULL) {
@@ -60,9 +70,11 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
     fputs(prev_anchor_location->anchor, page_file);
     fputs("' title='", page_file);
     fputs(prev_anchor_location->title, page_file);
+    fputs("' aria-label='Previous: ", page_file);
+    fputs(prev_anchor_location->title, page_file);
     fputs("'>&lt;</a>\n", page_file);
   } else
-    fputs("    <span>&nbsp;</span>", page_file);
+    fputs("    <span aria-hidden='true'>&nbsp;</span>", page_file);
 
   if (next_anchor_location != NULL) {
     fputs("    <a id='chapter-next-button' class='chapter-next' href='",
@@ -71,25 +83,36 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
     fputs(next_anchor_location->anchor, page_file);
     fputs("' title='", page_file);
     fputs(next_anchor_location->title, page_file);
+    fputs("' aria-label='Next: ", page_file);
+    fputs(next_anchor_location->title, page_file);
     fputs("'>&gt;</a>\n", page_file);
   } else
-    fputs("   <span>&nbsp;</span>", page_file);
+    fputs("   <span aria-hidden='true'>&nbsp;</span>", page_file);
 
   fputs("    </nav>\n", page_file);
   fputs("    </div>\n", page_file);
-  fputs("    <nav class='sidebar'>\n", page_file);
+  fputs("    <nav id='sidebar' class='sidebar' "
+        "aria-label='Table of contents'>\n",
+        page_file);
   int has_code_block = mmdoc_render_part(
       inputs.toc_path, page_file, RENDER_TYPE_MULTIPAGE, anchor_location,
       anchor_locations, anchor_location->multipage_url, NULL);
   fputs("    </nav>\n", page_file);
   fputs("    <section id='main'>\n", page_file);
-  fputs("      <nav class='nav-search' style='display:none;'>\n", page_file);
-  fputs("        <input type='search' id='search' placeholder='Search'>\n"
+  fputs("      <div id='search-panel' class='nav-search' role='search' "
+        "hidden>\n",
+        page_file);
+  fputs("        <label class='visually-hidden' for='search'>Search "
+        "documentation</label>\n"
+        "        <input type='search' id='search' placeholder='Search' "
+        "autocomplete='off' aria-controls='search-results'>\n"
+        "        <p id='search-status' class='visually-hidden' "
+        "role='status' aria-live='polite'></p>\n"
         "        <div id='search-results'></div>\n",
         page_file);
-  fputs("      </nav>\n", page_file);
+  fputs("      </div>\n", page_file);
   fputs("      <div class='main-scroll'>\n", page_file);
-  fputs("        <main>\n", page_file);
+  fputs("        <main id='main-content' tabindex='-1'>\n", page_file);
 
   if (anchor_location->file_path != NULL)
     has_code_block |= mmdoc_render_part(
@@ -101,12 +124,16 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
   fputs("      </div>\n", page_file);
   fputs("    </section>\n", page_file);
 
-  fputs("<script defer='true' src='search_index.js'></script>\n", page_file);
-
-  html_js(page_file);
-  html_search_js(page_file);
+  fputs("<script defer src='search_index.js'></script>\n", page_file);
   if (has_code_block)
-    html_highlight_js(page_file);
+    fputs("<script defer src='highlight.pack.js'></script>\n", page_file);
+  fputs("<script defer src='mmdoc.js'></script>\n"
+        "<script defer src='fuse.basic.min.js'></script>\n"
+        "<script defer src='mmdoc_search.js'></script>\n",
+        page_file);
+
+  if (has_code_blocks != NULL)
+    *has_code_blocks |= has_code_block;
 
   char *html_foot = "  </div>\n"
                     "  </body>\n"
@@ -122,6 +149,13 @@ int mmdoc_multi(Inputs inputs, AnchorLocationArray toc_anchor_locations,
   if (asset_write_to_dir_fuse_basic_min_js(out) != 0) {
     return -1;
   }
+  if (asset_write_to_dir_a11y_dark_css(out) != 0 ||
+      asset_write_to_dir_a11y_light_css(out) != 0 ||
+      asset_write_to_dir_mmdoc_css(out) != 0 ||
+      asset_write_to_dir_mmdoc_js(out) != 0 ||
+      asset_write_to_dir_mmdoc_search_js(out) != 0) {
+    return -1;
+  }
 
   char *search_index_js = "search_index.js";
   char *search_index_path =
@@ -132,6 +166,7 @@ int mmdoc_multi(Inputs inputs, AnchorLocationArray toc_anchor_locations,
 
   AnchorLocation *prev_anchor_location = NULL;
   AnchorLocation *next_anchor_location = NULL;
+  int has_code_blocks = 0;
   for (int i = 0; i < toc_anchor_locations.used; i++) {
     AnchorLocation *anchor_location = &toc_anchor_locations.array[i];
     if (i + 1 < toc_anchor_locations.used) {
@@ -141,11 +176,13 @@ int mmdoc_multi(Inputs inputs, AnchorLocationArray toc_anchor_locations,
     }
     mmdoc_multi_page(inputs, anchor_locations, search_index_file,
                      anchor_location, prev_anchor_location,
-                     next_anchor_location);
+                     next_anchor_location, &has_code_blocks);
     prev_anchor_location = anchor_location;
   }
   fseek(search_index_file, -1, SEEK_CUR);
   fputs("]", search_index_file);
   fclose(search_index_file);
+  if (has_code_blocks && asset_write_to_dir_highlight_pack_js(out) != 0)
+    return -1;
   return 0;
 }

--- a/src/multi.c
+++ b/src/multi.c
@@ -54,13 +54,13 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
         "aria-label='Toggle table of contents' aria-controls='sidebar' "
         "aria-expanded='true'></button>",
         page_file);
-  fputs("    <button type='button' class='search-toggle "
-        "emoji' aria-label='Open search' aria-controls='search-panel' "
-        "aria-expanded='false'>🔍&#xFE0E;</button>",
+  fputs("    <button type='button' class='search-toggle' "
+        "aria-label='Open search' aria-controls='search-panel' "
+        "aria-expanded='false'></button>",
         page_file);
-  fputs("    <button type='button' class='theme-toggle "
-        "emoji' aria-label='Switch to dark theme' "
-        "aria-pressed='false'>🌘&#xFE0E;</button>",
+  fputs("    <button type='button' class='theme-toggle' "
+        "aria-label='Switch to dark theme' "
+        "aria-pressed='false'></button>",
         page_file);
 
   if (prev_anchor_location != NULL) {

--- a/src/multi.h
+++ b/src/multi.h
@@ -8,6 +8,7 @@
 int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
                      FILE *search_index_file, AnchorLocation *anchor_location,
                      AnchorLocation *prev_anchor_location,
-                     AnchorLocation *next_anchor_location);
+                     AnchorLocation *next_anchor_location,
+                     int *has_code_blocks);
 int mmdoc_multi(Inputs inputs, AnchorLocationArray toc_anchor_locations,
                 AnchorLocationArray anchor_locations);

--- a/src/single.c
+++ b/src/single.c
@@ -64,9 +64,9 @@ int mmdoc_single(Inputs inputs, AnchorLocationArray toc_anchor_locations) {
         "aria-label='Toggle table of contents' aria-controls='sidebar' "
         "aria-expanded='true'></button>",
         index_file);
-  fputs("    <button type='button' class='theme-toggle "
-        "emoji' aria-label='Switch to dark theme' "
-        "aria-pressed='false'>🌘&#xFE0E;</button>",
+  fputs("    <button type='button' class='theme-toggle' "
+        "aria-label='Switch to dark theme' "
+        "aria-pressed='false'></button>",
         index_file);
   fputs("    </nav>\n"
         "    </div>\n",

--- a/src/single.c
+++ b/src/single.c
@@ -21,7 +21,7 @@ int mmdoc_single(Inputs inputs, AnchorLocationArray toc_anchor_locations) {
   index_file = fopen(index_path, "w");
 
   fputs("<!doctype html>\n"
-        "<html>\n"
+        "<html lang='en'>\n"
         "  <head>\n"
         "    <meta charset='utf-8'>\n"
         "    <meta name='viewport' content='width=device-width, "
@@ -50,22 +50,30 @@ int mmdoc_single(Inputs inputs, AnchorLocationArray toc_anchor_locations) {
         "  </head>\n"
         "  <body>\n",
         index_file);
-  fputs("  <input type='checkbox' id='sidebar-checkbox' style='display: "
-        "none;'/>\n",
+  fputs("  <a class='skip-link' href='#main-content'>Skip to main "
+        "content</a>\n"
+        "  <input type='checkbox' id='sidebar-checkbox' aria-hidden='true' "
+        "tabindex='-1' style='display: none;'>\n",
         index_file);
   fputs("    <div class='body'>\n"
         "      <div class='nav-top-container'>\n",
         index_file);
-  fputs("    <nav class='nav-top'>\n", index_file);
-  fputs("      <label for='sidebar-checkbox' class='sidebar-toggle'>≡</label>",
+  fputs("    <nav class='nav-top' aria-label='Documentation controls'>\n",
+        index_file);
+  fputs("      <button type='button' class='sidebar-toggle' "
+        "aria-label='Toggle table of contents' aria-controls='sidebar' "
+        "aria-expanded='true'></button>",
         index_file);
   fputs("    <button type='button' class='theme-toggle "
-        "emoji'>🌘&#xFE0E;</button>",
+        "emoji' aria-label='Switch to dark theme' "
+        "aria-pressed='false'>🌘&#xFE0E;</button>",
         index_file);
   fputs("    </nav>\n"
         "    </div>\n",
         index_file);
-  fputs("    <nav class='sidebar'>\n", index_file);
+  fputs("    <nav id='sidebar' class='sidebar' "
+        "aria-label='Table of contents'>\n",
+        index_file);
   AnchorLocation al;
   int has_code_block =
       mmdoc_render_part(inputs.toc_path, index_file, RENDER_TYPE_SINGLE, &al,
@@ -73,7 +81,7 @@ int mmdoc_single(Inputs inputs, AnchorLocationArray toc_anchor_locations) {
   fputs("    </nav>\n", index_file);
   fputs("    <section id='main'>\n", index_file);
   fputs("      <div class='main-scroll'>\n", index_file);
-  fputs("        <main>\n", index_file);
+  fputs("        <main id='main-content' tabindex='-1'>\n", index_file);
 
   for (int i = 0; i < toc_anchor_locations.used; i++) {
     AnchorLocationArray empty_anchor_locations;

--- a/test/test.c
+++ b/test/test.c
@@ -5,6 +5,7 @@
 #include "../src/multi.h"
 #include "../src/refs.h"
 #include "../src/render.h"
+#include "../src/single.h"
 #include <errno.h>
 #include <limits.h>
 #include <stdio.h>
@@ -338,6 +339,165 @@ int file_contains(char *path, const char *expected) {
   return found;
 }
 
+int file_exists_and_is_not_empty(char *path) {
+  FILE *file = fopen(path, "rb");
+  if (file == NULL)
+    return 0;
+  int first = fgetc(file);
+  fclose(file);
+  return first != EOF;
+}
+
+int write_text_file(char *path, const char *contents) {
+  FILE *file = fopen(path, "w");
+  if (file == NULL)
+    return 1;
+  int failed = fputs(contents, file) == EOF;
+  return fclose(file) != 0 || failed;
+}
+
+int test_multipage_shared_assets_and_accessible_controls() {
+  char root[] = "/tmp/mmdoc-assets-test-XXXXXX";
+  if (mkdtemp(root) == NULL)
+    return 1;
+
+  char page_path[PATH_MAX];
+  char toc_path[PATH_MAX];
+  char index_path[PATH_MAX];
+  snprintf(page_path, sizeof(page_path), "%s/page.md", root);
+  snprintf(toc_path, sizeof(toc_path), "%s/toc.md", root);
+  snprintf(index_path, sizeof(index_path), "%s/index.html", root);
+  if (write_text_file(page_path, "# Page {#page}\n\n```c\nint x;\n```\n") !=
+          0 ||
+      write_text_file(toc_path, "") != 0)
+    return 1;
+
+  Inputs inputs = {
+      .project_name = "Project",
+      .toc_path = toc_path,
+      .out_multi = root,
+  };
+  AnchorLocation page = {
+      .file_path = page_path,
+      .multipage_output_file_path = index_path,
+      .multipage_output_directory_path = root,
+      .multipage_base_href = "",
+      .multipage_url = "./",
+      .anchor = "#page",
+      .title = "Page",
+  };
+  AnchorLocationArray toc_anchor_locations;
+  AnchorLocationArray anchor_locations;
+  init_anchor_location_array(&toc_anchor_locations, 1);
+  init_anchor_location_array(&anchor_locations, 0);
+  insert_anchor_location_array(&toc_anchor_locations, &page);
+
+  int render_result =
+      mmdoc_multi(inputs, toc_anchor_locations, anchor_locations);
+  const char *asset_names[] = {
+      "a11y-dark.css",     "a11y-light.css",  "mmdoc.css",
+      "mmdoc.js",          "mmdoc_search.js", "fuse.basic.min.js",
+      "highlight.pack.js", "search_index.js",
+  };
+  int assets_found = 1;
+  for (size_t i = 0; i < sizeof(asset_names) / sizeof(asset_names[0]); i++) {
+    char asset_path[PATH_MAX];
+    snprintf(asset_path, sizeof(asset_path), "%s/%s", root, asset_names[i]);
+    assets_found &= file_exists_and_is_not_empty(asset_path);
+  }
+
+  int page_is_external = file_contains(index_path, "href='mmdoc.css'") &&
+                         file_contains(index_path, "src='mmdoc.js'") &&
+                         file_contains(index_path, "src='highlight.pack.js'") &&
+                         !file_contains(index_path, "<style>") &&
+                         !file_contains(index_path, "Highlight.js 10.7.1");
+  int page_is_accessible =
+      file_contains(index_path, "class='skip-link' href='#main-content'") &&
+      file_contains(index_path, "aria-controls='sidebar'") &&
+      file_contains(index_path, "aria-label='Open search'") &&
+      file_contains(index_path, "role='status' aria-live='polite'") &&
+      file_contains(index_path, "<main id='main-content' tabindex='-1'>");
+
+  for (size_t i = 0; i < sizeof(asset_names) / sizeof(asset_names[0]); i++) {
+    char asset_path[PATH_MAX];
+    snprintf(asset_path, sizeof(asset_path), "%s/%s", root, asset_names[i]);
+    unlink(asset_path);
+  }
+  int no_code_render_result = 1;
+  int highlighter_is_conditional = 0;
+  if (write_text_file(page_path, "# Page {#page}\n") == 0) {
+    no_code_render_result =
+        mmdoc_multi(inputs, toc_anchor_locations, anchor_locations);
+    char highlighter_path[PATH_MAX];
+    snprintf(highlighter_path, sizeof(highlighter_path), "%s/highlight.pack.js",
+             root);
+    highlighter_is_conditional =
+        !file_exists_and_is_not_empty(highlighter_path) &&
+        !file_contains(index_path, "src='highlight.pack.js'");
+  }
+  for (size_t i = 0; i < sizeof(asset_names) / sizeof(asset_names[0]); i++) {
+    char asset_path[PATH_MAX];
+    snprintf(asset_path, sizeof(asset_path), "%s/%s", root, asset_names[i]);
+    unlink(asset_path);
+  }
+
+  free_anchor_location_array(&toc_anchor_locations);
+  free_anchor_location_array(&anchor_locations);
+  unlink(index_path);
+  unlink(page_path);
+  unlink(toc_path);
+  rmdir(root);
+
+  if (render_result != 0 || no_code_render_result != 0 || !assets_found ||
+      !page_is_external || !page_is_accessible || !highlighter_is_conditional) {
+    printf("multipage shared asset and accessibility test failed\n");
+    return 1;
+  }
+  printf("multipage shared asset and accessibility test passed\n");
+  return 0;
+}
+
+int test_single_page_accessible_controls() {
+  char root[] = "/tmp/mmdoc-single-accessibility-test-XXXXXX";
+  if (mkdtemp(root) == NULL)
+    return 1;
+
+  char toc_path[PATH_MAX];
+  char out_path[PATH_MAX];
+  char index_path[PATH_MAX];
+  snprintf(toc_path, sizeof(toc_path), "%s/toc.md", root);
+  snprintf(out_path, sizeof(out_path), "%s/single", root);
+  snprintf(index_path, sizeof(index_path), "%s/index.html", out_path);
+  if (write_text_file(toc_path, "") != 0)
+    return 1;
+
+  Inputs inputs = {
+      .project_name = "Project",
+      .toc_path = toc_path,
+      .out_single = out_path,
+  };
+  AnchorLocationArray toc_anchor_locations;
+  init_anchor_location_array(&toc_anchor_locations, 0);
+  int render_result = mmdoc_single(inputs, toc_anchor_locations);
+  int controls_found = file_contains(index_path, "<html lang='en'>") &&
+                       file_contains(index_path, "aria-controls='sidebar'") &&
+                       file_contains(index_path, "aria-pressed='false'") &&
+                       file_contains(index_path, "id='main-content'");
+
+  free_anchor_location_array(&toc_anchor_locations);
+  unlink(index_path);
+  unlink(toc_path);
+  rmdir(out_path);
+  rmdir(root);
+
+  if (render_result != 0 || !controls_found) {
+    printf("single-page accessibility test failed\n");
+    return 1;
+  }
+  printf("single-page accessibility test passed\n");
+  return 0;
+}
+
 int test_multipage_navigation_anchor() {
   char root[] = "/tmp/mmdoc-navigation-test-XXXXXX";
   if (mkdtemp(root) == NULL)
@@ -383,8 +543,9 @@ int test_multipage_navigation_anchor() {
   AnchorLocationArray anchor_locations;
   init_anchor_location_array(&anchor_locations, 0);
 
-  int render_result = mmdoc_multi_page(
-      inputs, anchor_locations, search_index_file, &current, &previous, &next);
+  int render_result =
+      mmdoc_multi_page(inputs, anchor_locations, search_index_file, &current,
+                       &previous, &next, NULL);
   int found_previous = file_contains(
       page_path, "id='chapter-previous-button' class='chapter-previous' "
                  "href='./#preface'");
@@ -489,6 +650,10 @@ int main(int argc, char *argv[]) {
   num_failed += test_zero_capacity_arrays();
   num_tests++;
   num_failed += test_multipage_navigation_anchor();
+  num_tests++;
+  num_failed += test_multipage_shared_assets_and_accessible_controls();
+  num_tests++;
+  num_failed += test_single_page_accessible_controls();
   num_tests++;
   num_failed += test_reject_overlong_ids();
   num_tests++;


### PR DESCRIPTION
## Summary

- emit cacheable CSS and JavaScript files once for multipage output while keeping single-page output self-contained
- preserve conditional Highlight.js generation and reduce the manual multipage output from 4.1 MB to 1.1 MB
- add semantic, stateful sidebar, search, theme, and chapter controls with skip-link and live-region support
- manage search focus and keyboard shortcuts, including cycling between the search box and results with the arrow keys
- document the generated assets and keyboard interface, with regression coverage for both output modes

## Testing

- `nix develop -c meson test -C build-normal --print-errorlogs`
- `nix build .#mmdoc-docs -L`
- `nix develop -c clang-format --dry-run --Werror src/asset.c src/asset.h src/html.c src/html.h src/multi.c src/multi.h src/single.c test/test.c`
- `git diff --check`
- verified shared asset loading and initialized accessibility state in headless Chrome