### PR TITLE
Improve rendering performance and asset caching

### DIFF
--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -34,27 +34,28 @@ and outputs
 ```text
 out
 ├── multi
-│   ├── a11y-dark.css
-│   ├── a11y-light.css
+│   ├── a11y-dark.<hash>.css
+│   ├── a11y-light.<hash>.css
 │   ├── development
 │   │   └── index.html
 │   ├── features
 │   │   └── index.html
-│   ├── fuse.basic.min.js
-│   ├── highlight.pack.js
+│   ├── fuse.basic.min.<hash>.js
+│   ├── highlight.pack.<hash>.js
 │   ├── index.html
 │   ├── license
 │   │   └── index.html
-│   ├── mmdoc.css
-│   ├── mmdoc.js
-│   ├── mmdoc_search.js
-│   ├── search_index.js
+│   ├── mmdoc.<hash>.css
+│   ├── mmdoc.<hash>.js
+│   ├── mmdoc_search.<hash>.js
+│   ├── search_index.<hash>.js
 │   └── usage
 │       └── index.html
 └── single
     └── index.html
 ```
 
-The multi-page output uses shared, cacheable assets. The single-page output
+The multi-page output uses shared assets with content hashes in their names so
+browsers can cache them without serving stale content. The single-page output
 embeds its styling and scripts in `index.html` so it remains portable as one
 file.

--- a/src/anchors.c
+++ b/src/anchors.c
@@ -142,7 +142,7 @@ int mmdoc_anchors_locations(AnchorLocationArray *anchor_locations,
     }
     free(title);
   }
-  return 0;
+  return build_anchor_location_index(anchor_locations);
 }
 
 int mmdoc_anchors_find_toc_anchors(AnchorLocationArray *toc_anchor_locations,
@@ -150,16 +150,9 @@ int mmdoc_anchors_find_toc_anchors(AnchorLocationArray *toc_anchor_locations,
                                    AnchorLocationArray *anchor_locations) {
 
   for (int i = 0; i < toc_refs->used; i++) {
-    AnchorLocation *anchor_location;
-    int found = 0;
-    for (int j = 0; j < anchor_locations->used; j++) {
-      if (strcmp(toc_refs->array[i], anchor_locations->array[j].anchor) == 0) {
-        anchor_location = &anchor_locations->array[j];
-        found = 1;
-        break;
-      }
-    }
-    if (!found) {
+    AnchorLocation *anchor_location =
+        find_anchor_location(anchor_locations, toc_refs->array[i]);
+    if (anchor_location == NULL) {
       printf("Anchor \"%s\" referenced in toc.md not found.\n",
              toc_refs->array[i]);
       return -1;

--- a/src/asset.c
+++ b/src/asset.c
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: CC0-1.0 */
+#include "asset.h"
 #include "a11y-dark.css.h"
 #include "a11y-light.css.h"
 #include "fuse.basic.min.js.h"
@@ -8,11 +9,98 @@
 #include "mmdoc_search.js.h"
 
 #include <errno.h>
+#include <inttypes.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 extern int errno;
+
+extern unsigned char ___src_asset_highlight_pack_js[];
+extern unsigned int ___src_asset_highlight_pack_js_len;
+extern unsigned char ___src_asset_fuse_basic_min_js[];
+extern unsigned int ___src_asset_fuse_basic_min_js_len;
+extern unsigned char ___src_asset_a11y_light_css[];
+extern unsigned int ___src_asset_a11y_light_css_len;
+extern unsigned char ___src_asset_a11y_dark_css[];
+extern unsigned int ___src_asset_a11y_dark_css_len;
+extern unsigned char ___src_asset_mmdoc_css[];
+extern unsigned int ___src_asset_mmdoc_css_len;
+extern unsigned char ___src_asset_mmdoc_js[];
+extern unsigned int ___src_asset_mmdoc_js_len;
+extern unsigned char ___src_asset_mmdoc_search_js[];
+extern unsigned int ___src_asset_mmdoc_search_js_len;
+
+static uint64_t asset_hash_update(uint64_t hash, const unsigned char *bytes,
+                                  size_t length) {
+  for (size_t i = 0; i < length; i++) {
+    hash ^= bytes[i];
+    hash *= UINT64_C(1099511628211);
+  }
+  return hash;
+}
+
+static uint64_t asset_hash(const unsigned char *bytes, size_t length) {
+  return asset_hash_update(UINT64_C(14695981039346656037), bytes, length);
+}
+
+static void asset_hashed_file_name(const char *stem, const char *extension,
+                                   const unsigned char *bytes, size_t length,
+                                   char *file_name, size_t file_name_size) {
+  snprintf(file_name, file_name_size, "%s.%016" PRIx64 ".%s", stem,
+           asset_hash(bytes, length), extension);
+}
+
+void asset_file_names(AssetFileNames *names) {
+  asset_hashed_file_name("fuse.basic.min", "js", ___src_asset_fuse_basic_min_js,
+                         ___src_asset_fuse_basic_min_js_len,
+                         names->fuse_basic_min_js,
+                         sizeof(names->fuse_basic_min_js));
+  asset_hashed_file_name("highlight.pack", "js", ___src_asset_highlight_pack_js,
+                         ___src_asset_highlight_pack_js_len,
+                         names->highlight_pack_js,
+                         sizeof(names->highlight_pack_js));
+  asset_hashed_file_name("a11y-dark", "css", ___src_asset_a11y_dark_css,
+                         ___src_asset_a11y_dark_css_len, names->a11y_dark_css,
+                         sizeof(names->a11y_dark_css));
+  asset_hashed_file_name("a11y-light", "css", ___src_asset_a11y_light_css,
+                         ___src_asset_a11y_light_css_len, names->a11y_light_css,
+                         sizeof(names->a11y_light_css));
+  asset_hashed_file_name("mmdoc", "css", ___src_asset_mmdoc_css,
+                         ___src_asset_mmdoc_css_len, names->mmdoc_css,
+                         sizeof(names->mmdoc_css));
+  asset_hashed_file_name("mmdoc", "js", ___src_asset_mmdoc_js,
+                         ___src_asset_mmdoc_js_len, names->mmdoc_js,
+                         sizeof(names->mmdoc_js));
+  asset_hashed_file_name("mmdoc_search", "js", ___src_asset_mmdoc_search_js,
+                         ___src_asset_mmdoc_search_js_len,
+                         names->mmdoc_search_js,
+                         sizeof(names->mmdoc_search_js));
+}
+
+int asset_hashed_file_name_from_path(const char *path, const char *stem,
+                                     const char *extension, char *file_name,
+                                     size_t file_name_size) {
+  FILE *file = fopen(path, "rb");
+  if (file == NULL)
+    return -1;
+
+  uint64_t hash = UINT64_C(14695981039346656037);
+  unsigned char buffer[64 * 1024];
+  size_t bytes_read;
+  while ((bytes_read = fread(buffer, 1, sizeof(buffer), file)) > 0)
+    hash = asset_hash_update(hash, buffer, bytes_read);
+  int read_failed = ferror(file);
+  int close_failed = fclose(file) != 0;
+  int failed = read_failed || close_failed;
+  if (failed)
+    return -1;
+
+  snprintf(file_name, file_name_size, "%s.%016" PRIx64 ".%s", stem, hash,
+           extension);
+  return 0;
+}
 
 static int asset_write_to_file(FILE *file, unsigned char *asset_array,
                                unsigned int asset_array_length) {
@@ -23,7 +111,7 @@ static int asset_write_to_file(FILE *file, unsigned char *asset_array,
   return 0;
 }
 
-static int asset_write_to_dir(char *dir, char *asset_file_name,
+static int asset_write_to_dir(char *dir, const char *asset_file_name,
                               unsigned char *asset_array,
                               unsigned int asset_array_length) {
   char *asset_path = malloc(strlen(dir) + 1 + strlen(asset_file_name) + 1);
@@ -53,73 +141,56 @@ static int asset_write_to_dir(char *dir, char *asset_file_name,
   return 0;
 }
 
-extern unsigned char ___src_asset_highlight_pack_js[];
-extern unsigned int ___src_asset_highlight_pack_js_len;
 int asset_write_to_file_highlight_pack_js(FILE *file) {
   return asset_write_to_file(file, ___src_asset_highlight_pack_js,
                              ___src_asset_highlight_pack_js_len);
 }
-int asset_write_to_dir_highlight_pack_js(char *dir) {
-  return asset_write_to_dir(dir, "highlight.pack.js",
-                            ___src_asset_highlight_pack_js,
+int asset_write_to_dir_highlight_pack_js(char *dir, const char *file_name) {
+  return asset_write_to_dir(dir, file_name, ___src_asset_highlight_pack_js,
                             ___src_asset_highlight_pack_js_len);
 }
 
-extern unsigned char ___src_asset_fuse_basic_min_js[];
-extern unsigned int ___src_asset_fuse_basic_min_js_len;
-int asset_write_to_dir_fuse_basic_min_js(char *dir) {
-  return asset_write_to_dir(dir, "fuse.basic.min.js",
-                            ___src_asset_fuse_basic_min_js,
+int asset_write_to_dir_fuse_basic_min_js(char *dir, const char *file_name) {
+  return asset_write_to_dir(dir, file_name, ___src_asset_fuse_basic_min_js,
                             ___src_asset_fuse_basic_min_js_len);
 }
-extern unsigned char ___src_asset_a11y_light_css[];
-extern unsigned int ___src_asset_a11y_light_css_len;
 int asset_write_to_file_a11y_light_css(FILE *file) {
   return asset_write_to_file(file, ___src_asset_a11y_light_css,
                              ___src_asset_a11y_light_css_len);
 }
-int asset_write_to_dir_a11y_light_css(char *dir) {
-  return asset_write_to_dir(dir, "a11y-light.css", ___src_asset_a11y_light_css,
+int asset_write_to_dir_a11y_light_css(char *dir, const char *file_name) {
+  return asset_write_to_dir(dir, file_name, ___src_asset_a11y_light_css,
                             ___src_asset_a11y_light_css_len);
 }
 
-extern unsigned char ___src_asset_a11y_dark_css[];
-extern unsigned int ___src_asset_a11y_dark_css_len;
 int asset_write_to_file_a11y_dark_css(FILE *file) {
   return asset_write_to_file(file, ___src_asset_a11y_dark_css,
                              ___src_asset_a11y_dark_css_len);
 }
-int asset_write_to_dir_a11y_dark_css(char *dir) {
-  return asset_write_to_dir(dir, "a11y-dark.css", ___src_asset_a11y_dark_css,
+int asset_write_to_dir_a11y_dark_css(char *dir, const char *file_name) {
+  return asset_write_to_dir(dir, file_name, ___src_asset_a11y_dark_css,
                             ___src_asset_a11y_dark_css_len);
 }
 
-extern unsigned char ___src_asset_mmdoc_css[];
-extern unsigned int ___src_asset_mmdoc_css_len;
 int asset_write_to_file_mmdoc_css(FILE *file) {
   return asset_write_to_file(file, ___src_asset_mmdoc_css,
                              ___src_asset_mmdoc_css_len);
 }
-int asset_write_to_dir_mmdoc_css(char *dir) {
-  return asset_write_to_dir(dir, "mmdoc.css", ___src_asset_mmdoc_css,
+int asset_write_to_dir_mmdoc_css(char *dir, const char *file_name) {
+  return asset_write_to_dir(dir, file_name, ___src_asset_mmdoc_css,
                             ___src_asset_mmdoc_css_len);
 }
 
-extern unsigned char ___src_asset_mmdoc_js[];
-extern unsigned int ___src_asset_mmdoc_js_len;
 int asset_write_to_file_mmdoc_js(FILE *file) {
   return asset_write_to_file(file, ___src_asset_mmdoc_js,
                              ___src_asset_mmdoc_js_len);
 }
-int asset_write_to_dir_mmdoc_js(char *dir) {
-  return asset_write_to_dir(dir, "mmdoc.js", ___src_asset_mmdoc_js,
+int asset_write_to_dir_mmdoc_js(char *dir, const char *file_name) {
+  return asset_write_to_dir(dir, file_name, ___src_asset_mmdoc_js,
                             ___src_asset_mmdoc_js_len);
 }
 
-extern unsigned char ___src_asset_mmdoc_search_js[];
-extern unsigned int ___src_asset_mmdoc_search_js_len;
-int asset_write_to_dir_mmdoc_search_js(char *dir) {
-  return asset_write_to_dir(dir, "mmdoc_search.js",
-                            ___src_asset_mmdoc_search_js,
+int asset_write_to_dir_mmdoc_search_js(char *dir, const char *file_name) {
+  return asset_write_to_dir(dir, file_name, ___src_asset_mmdoc_search_js,
                             ___src_asset_mmdoc_search_js_len);
 }

--- a/src/asset.h
+++ b/src/asset.h
@@ -3,13 +3,30 @@
 
 #include <stdio.h>
 
-int asset_write_to_dir_fuse_basic_min_js(char *dir);
-int asset_write_to_dir_highlight_pack_js(char *dir);
-int asset_write_to_dir_a11y_dark_css(char *dir);
-int asset_write_to_dir_a11y_light_css(char *dir);
-int asset_write_to_dir_mmdoc_css(char *dir);
-int asset_write_to_dir_mmdoc_js(char *dir);
-int asset_write_to_dir_mmdoc_search_js(char *dir);
+#define ASSET_FILE_NAME_SIZE 96
+
+typedef struct {
+  char fuse_basic_min_js[ASSET_FILE_NAME_SIZE];
+  char highlight_pack_js[ASSET_FILE_NAME_SIZE];
+  char a11y_dark_css[ASSET_FILE_NAME_SIZE];
+  char a11y_light_css[ASSET_FILE_NAME_SIZE];
+  char mmdoc_css[ASSET_FILE_NAME_SIZE];
+  char mmdoc_js[ASSET_FILE_NAME_SIZE];
+  char mmdoc_search_js[ASSET_FILE_NAME_SIZE];
+} AssetFileNames;
+
+void asset_file_names(AssetFileNames *names);
+int asset_hashed_file_name_from_path(const char *path, const char *stem,
+                                     const char *extension, char *file_name,
+                                     size_t file_name_size);
+
+int asset_write_to_dir_fuse_basic_min_js(char *dir, const char *file_name);
+int asset_write_to_dir_highlight_pack_js(char *dir, const char *file_name);
+int asset_write_to_dir_a11y_dark_css(char *dir, const char *file_name);
+int asset_write_to_dir_a11y_light_css(char *dir, const char *file_name);
+int asset_write_to_dir_mmdoc_css(char *dir, const char *file_name);
+int asset_write_to_dir_mmdoc_js(char *dir, const char *file_name);
+int asset_write_to_dir_mmdoc_search_js(char *dir, const char *file_name);
 
 int asset_write_to_file_a11y_dark_css(FILE *file);
 int asset_write_to_file_a11y_light_css(FILE *file);

--- a/src/asset/mmdoc_search.js
+++ b/src/asset/mmdoc_search.js
@@ -1,6 +1,9 @@
 //// Search
 
 const searchResultLimit = 50
+const searchAssetScript = document.currentScript
+const searchIndexSource = searchAssetScript.dataset.searchIndex
+const fuseSource = searchAssetScript.dataset.fuse
 let searchIndex = null
 let searchLoadPromise = null
 let searchPreviousFocus = null
@@ -22,8 +25,8 @@ function loadSearchAssets() {
   const statusElem = document.getElementById('search-status')
   statusElem.textContent = 'Loading search'
   searchLoadPromise = Promise.all([
-    loadSearchScript('search_index.js'),
-    loadSearchScript('fuse.basic.min.js')
+    loadSearchScript(searchIndexSource),
+    loadSearchScript(fuseSource)
   ]).then(() => {
     const searchCorpus = typeof corpus === 'undefined'
       ? window.mmdocSearchCorpus

--- a/src/asset/mmdoc_search.js
+++ b/src/asset/mmdoc_search.js
@@ -25,7 +25,12 @@ function loadSearchAssets() {
     loadSearchScript('search_index.js'),
     loadSearchScript('fuse.basic.min.js')
   ]).then(() => {
-    searchIndex = new Fuse(window.mmdocSearchCorpus, {
+    const searchCorpus = typeof corpus === 'undefined'
+      ? window.mmdocSearchCorpus
+      : corpus
+    if (!Array.isArray(searchCorpus))
+      throw new Error('Search corpus did not load')
+    searchIndex = new Fuse(searchCorpus, {
       keys: ['title', 'text'],
       ignoreLocation: true,
       threshold: 0.01,

--- a/src/asset/mmdoc_search.js
+++ b/src/asset/mmdoc_search.js
@@ -1,39 +1,92 @@
 //// Search
 
+const searchResultLimit = 50
+let searchIndex = null
+let searchLoadPromise = null
+let searchPreviousFocus = null
+
+function loadSearchScript(source) {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script')
+    script.src = source
+    script.addEventListener('load', resolve, { once: true })
+    script.addEventListener('error', reject, { once: true })
+    document.head.appendChild(script)
+  })
+}
+
+function loadSearchAssets() {
+  if (searchLoadPromise !== null)
+    return searchLoadPromise
+
+  const statusElem = document.getElementById('search-status')
+  statusElem.textContent = 'Loading search'
+  searchLoadPromise = Promise.all([
+    loadSearchScript('search_index.js'),
+    loadSearchScript('fuse.basic.min.js')
+  ]).then(() => {
+    searchIndex = new Fuse(window.mmdocSearchCorpus, {
+      keys: ['title', 'text'],
+      ignoreLocation: true,
+      threshold: 0.01,
+      minMatchCharLength: 3
+    })
+    if (document.getElementById('search').value === '')
+      statusElem.textContent = ''
+    return true
+  }).catch(() => {
+    statusElem.textContent = 'Search is unavailable'
+    return false
+  })
+  return searchLoadPromise
+}
+
 function setupSearch() {
-  const fuse = new Fuse(corpus, { keys: ['title', 'text'], ignoreLocation: true, threshold: 0.01, minMatchCharLength: 3 })
   const input = document.getElementById('search')
   const resultsElem = document.getElementById('search-results')
   const statusElem = document.getElementById('search-status')
   let timeout = null
+
+  function runSearch() {
+    resultsElem.replaceChildren()
+    statusElem.textContent = ''
+    if (input.value === '' || searchIndex === null)
+      return
+
+    const results = searchIndex.search(
+      input.value, { limit: searchResultLimit })
+    const resultLabel = results.length === 1 ? 'search result' : 'search results'
+    statusElem.textContent = results.length + ' ' + resultLabel
+    const h2 = document.createElement('h2')
+    h2.appendChild(document.createTextNode(results.length + ' ' + resultLabel))
+    resultsElem.appendChild(h2)
+    const ol = document.createElement('ol')
+    resultsElem.appendChild(ol)
+    results.forEach(function (result) {
+      const li = document.createElement('li')
+      const a = document.createElement('a')
+      a.href = result.item.url
+      a.appendChild(document.createTextNode(result.item.title))
+      li.appendChild(a)
+      ol.appendChild(li)
+    })
+  }
+
   input.addEventListener('input', function () {
     clearTimeout(timeout)
-    timeout = setTimeout(function () {
-      resultsElem.innerHTML = ""
-      statusElem.textContent = ""
-      if (input.value === "")
+    if (input.value === '') {
+      resultsElem.replaceChildren()
+      statusElem.textContent = ''
+      return
+    }
+    loadSearchAssets().then(loaded => {
+      if (!loaded)
         return
-      const results = fuse.search(input.value)
-      const resultLabel = results.length === 1 ? 'search result' : 'search results'
-      statusElem.textContent = results.length + ' ' + resultLabel
-      const h2 = document.createElement('h2')
-      h2.appendChild(document.createTextNode(results.length + ' ' + resultLabel))
-      resultsElem.appendChild(h2)
-      const ol = document.createElement('ol')
-      resultsElem.appendChild(ol)
-      results.forEach(function (result) {
-        const li = document.createElement('li')
-        const a = document.createElement('a')
-        a.href = result.item.url
-        a.appendChild(document.createTextNode(result.item.title))
-        li.appendChild(a)
-        ol.appendChild(li)
-      })
-    }, 100)
+      clearTimeout(timeout)
+      timeout = setTimeout(runSearch, 100)
+    })
   })
 }
-
-let searchPreviousFocus = null
 
 function moveSearchResultFocus(direction) {
   const input = document.getElementById('search')
@@ -72,6 +125,7 @@ function setSearchVisible(visible) {
       setSidebarVisible(false)
     input.focus()
     input.select()
+    loadSearchAssets()
   } else if (searchPreviousFocus !== null) {
     searchPreviousFocus.focus()
     searchPreviousFocus = null

--- a/src/asset/mmdoc_search.js
+++ b/src/asset/mmdoc_search.js
@@ -28,9 +28,7 @@ function loadSearchAssets() {
     loadSearchScript(searchIndexSource),
     loadSearchScript(fuseSource)
   ]).then(() => {
-    const searchCorpus = typeof corpus === 'undefined'
-      ? window.mmdocSearchCorpus
-      : corpus
+    const searchCorpus = window.mmdocSearchCorpus
     if (!Array.isArray(searchCorpus))
       throw new Error('Search corpus did not load')
     searchIndex = new Fuse(searchCorpus, {

--- a/src/multi.c
+++ b/src/multi.c
@@ -6,6 +6,46 @@
 #include <string.h>
 
 static char toc_current_page_url[] = "__MMDOC_CURRENT_PAGE_URL__";
+static char search_index_placeholder[] = "search_index.0000000000000000.js";
+
+static char *asset_path(const char *dir, const char *file_name) {
+  char *path = malloc(strlen(dir) + 1 + strlen(file_name) + 1);
+  if (path != NULL)
+    sprintf(path, "%s/%s", dir, file_name);
+  return path;
+}
+
+static int replace_file_name(const char *path, long offset,
+                             const char *old_file_name,
+                             const char *new_file_name) {
+  if (strlen(old_file_name) != strlen(new_file_name))
+    return -1;
+
+  FILE *file = fopen(path, "r+b");
+  if (file == NULL)
+    return -1;
+  if (fseek(file, offset, SEEK_SET) != 0) {
+    fclose(file);
+    return -1;
+  }
+
+  char existing_file_name[ASSET_FILE_NAME_SIZE];
+  size_t file_name_length = strlen(old_file_name);
+  size_t bytes_read = fread(existing_file_name, 1, file_name_length, file);
+  existing_file_name[bytes_read] = '\0';
+  if (bytes_read != file_name_length ||
+      (strcmp(existing_file_name, old_file_name) != 0 &&
+       strcmp(existing_file_name, new_file_name) != 0)) {
+    fclose(file);
+    return -1;
+  }
+
+  int failed = strcmp(existing_file_name, new_file_name) != 0 &&
+               (fseek(file, offset, SEEK_SET) != 0 ||
+                fwrite(new_file_name, 1, strlen(new_file_name), file) !=
+                    strlen(new_file_name));
+  return fclose(file) != 0 || failed ? -1 : 0;
+}
 
 static int write_toc(FILE *page_file, const char *toc_html,
                      const char *multipage_url) {
@@ -60,7 +100,10 @@ static int render_toc(Inputs inputs, AnchorLocationArray anchor_locations,
 
 int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
                      const char *toc_html, int toc_has_code_block,
-                     FILE *search_index_file, AnchorLocation *anchor_location,
+                     const AssetFileNames *asset_names,
+                     const char *search_index_name, FILE *search_index_file,
+                     long *search_index_name_offset,
+                     AnchorLocation *anchor_location,
                      AnchorLocation *prev_anchor_location,
                      AnchorLocation *next_anchor_location,
                      int *has_code_blocks) {
@@ -83,10 +126,13 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
   fputs("'>\n"
         "    <link rel='icon' href='favicon.svg'>\n",
         page_file);
-  fputs("    <link rel='stylesheet' href='a11y-dark.css'>\n"
-        "    <link rel='stylesheet' href='a11y-light.css'>\n"
-        "    <link rel='stylesheet' href='mmdoc.css'>\n",
-        page_file);
+  fputs("    <link rel='stylesheet' href='", page_file);
+  fputs(asset_names->a11y_dark_css, page_file);
+  fputs("'>\n    <link rel='stylesheet' href='", page_file);
+  fputs(asset_names->a11y_light_css, page_file);
+  fputs("'>\n    <link rel='stylesheet' href='", page_file);
+  fputs(asset_names->mmdoc_css, page_file);
+  fputs("'>\n", page_file);
   fputs("    <title>", page_file);
   fputs(anchor_location->title, page_file);
   fputs(" | ", page_file);
@@ -180,11 +226,22 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
   fputs("      </div>\n", page_file);
   fputs("    </section>\n", page_file);
 
-  if (has_code_block)
-    fputs("<script defer src='highlight.pack.js'></script>\n", page_file);
-  fputs("<script defer src='mmdoc.js'></script>\n"
-        "<script defer src='mmdoc_search.js'></script>\n",
-        page_file);
+  if (has_code_block) {
+    fputs("<script defer src='", page_file);
+    fputs(asset_names->highlight_pack_js, page_file);
+    fputs("'></script>\n", page_file);
+  }
+  fputs("<script defer src='", page_file);
+  fputs(asset_names->mmdoc_js, page_file);
+  fputs("'></script>\n<script defer src='", page_file);
+  fputs(asset_names->mmdoc_search_js, page_file);
+  fputs("' data-search-index='", page_file);
+  if (search_index_name_offset != NULL)
+    *search_index_name_offset = ftell(page_file);
+  fputs(search_index_name, page_file);
+  fputs("' data-fuse='", page_file);
+  fputs(asset_names->fuse_basic_min_js, page_file);
+  fputs("'></script>\n", page_file);
 
   if (has_code_blocks != NULL)
     *has_code_blocks |= has_code_block;
@@ -200,22 +257,29 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
 int mmdoc_multi(Inputs inputs, AnchorLocationArray toc_anchor_locations,
                 AnchorLocationArray anchor_locations) {
   char *out = inputs.out_multi;
-  if (asset_write_to_dir_fuse_basic_min_js(out) != 0) {
+  AssetFileNames asset_names;
+  asset_file_names(&asset_names);
+  if (asset_write_to_dir_fuse_basic_min_js(
+          out, asset_names.fuse_basic_min_js) != 0) {
     return -1;
   }
-  if (asset_write_to_dir_a11y_dark_css(out) != 0 ||
-      asset_write_to_dir_a11y_light_css(out) != 0 ||
-      asset_write_to_dir_mmdoc_css(out) != 0 ||
-      asset_write_to_dir_mmdoc_js(out) != 0 ||
-      asset_write_to_dir_mmdoc_search_js(out) != 0) {
+  if (asset_write_to_dir_a11y_dark_css(out, asset_names.a11y_dark_css) != 0 ||
+      asset_write_to_dir_a11y_light_css(out, asset_names.a11y_light_css) != 0 ||
+      asset_write_to_dir_mmdoc_css(out, asset_names.mmdoc_css) != 0 ||
+      asset_write_to_dir_mmdoc_js(out, asset_names.mmdoc_js) != 0 ||
+      asset_write_to_dir_mmdoc_search_js(out, asset_names.mmdoc_search_js) !=
+          0) {
     return -1;
   }
 
-  char *search_index_js = "search_index.js";
-  char *search_index_path =
-      malloc(strlen(out) + 1 + strlen(search_index_js) + 1);
-  sprintf(search_index_path, "%s/%s", out, search_index_js);
+  char *search_index_path = asset_path(out, "search_index.tmp");
+  if (search_index_path == NULL)
+    return -1;
   FILE *search_index_file = fopen(search_index_path, "w");
+  if (search_index_file == NULL) {
+    free(search_index_path);
+    return -1;
+  }
   fputs("window.mmdocSearchCorpus = [", search_index_file);
 
   char *toc_html = NULL;
@@ -230,6 +294,17 @@ int mmdoc_multi(Inputs inputs, AnchorLocationArray toc_anchor_locations,
   AnchorLocation *prev_anchor_location = NULL;
   AnchorLocation *next_anchor_location = NULL;
   int has_code_blocks = 0;
+  long *search_index_name_offsets = NULL;
+  if (toc_anchor_locations.used > 0) {
+    search_index_name_offsets =
+        malloc(toc_anchor_locations.used * sizeof(*search_index_name_offsets));
+    if (search_index_name_offsets == NULL) {
+      free(toc_html);
+      fclose(search_index_file);
+      free(search_index_path);
+      return -1;
+    }
+  }
   for (int i = 0; i < toc_anchor_locations.used; i++) {
     AnchorLocation *anchor_location = &toc_anchor_locations.array[i];
     if (i + 1 < toc_anchor_locations.used) {
@@ -238,10 +313,12 @@ int mmdoc_multi(Inputs inputs, AnchorLocationArray toc_anchor_locations,
       next_anchor_location = NULL;
     }
     if (mmdoc_multi_page(inputs, anchor_locations, toc_html, toc_has_code_block,
-                         search_index_file, anchor_location,
-                         prev_anchor_location, next_anchor_location,
-                         &has_code_blocks) != 0) {
+                         &asset_names, search_index_placeholder,
+                         search_index_file, &search_index_name_offsets[i],
+                         anchor_location, prev_anchor_location,
+                         next_anchor_location, &has_code_blocks) != 0) {
       free(toc_html);
+      free(search_index_name_offsets);
       fclose(search_index_file);
       free(search_index_path);
       return -1;
@@ -249,11 +326,49 @@ int mmdoc_multi(Inputs inputs, AnchorLocationArray toc_anchor_locations,
     prev_anchor_location = anchor_location;
   }
   free(toc_html);
-  fseek(search_index_file, -1, SEEK_CUR);
-  fputs("]", search_index_file);
-  fclose(search_index_file);
+  int search_index_failed = toc_anchor_locations.used > 0 &&
+                            fseek(search_index_file, -1, SEEK_CUR) != 0;
+  if (!search_index_failed && fputs("]", search_index_file) == EOF)
+    search_index_failed = 1;
+  if (fclose(search_index_file) != 0)
+    search_index_failed = 1;
+  if (search_index_failed) {
+    free(search_index_path);
+    free(search_index_name_offsets);
+    return -1;
+  }
+
+  char search_index_name[ASSET_FILE_NAME_SIZE];
+  if (asset_hashed_file_name_from_path(search_index_path, "search_index", "js",
+                                       search_index_name,
+                                       sizeof(search_index_name)) != 0) {
+    free(search_index_path);
+    free(search_index_name_offsets);
+    return -1;
+  }
+  char *final_search_index_path = asset_path(out, search_index_name);
+  if (final_search_index_path == NULL ||
+      rename(search_index_path, final_search_index_path) != 0) {
+    free(final_search_index_path);
+    free(search_index_path);
+    free(search_index_name_offsets);
+    return -1;
+  }
+  free(final_search_index_path);
   free(search_index_path);
-  if (has_code_blocks && asset_write_to_dir_highlight_pack_js(out) != 0)
+
+  for (int i = 0; i < toc_anchor_locations.used; i++)
+    if (replace_file_name(
+            toc_anchor_locations.array[i].multipage_output_file_path,
+            search_index_name_offsets[i], search_index_placeholder,
+            search_index_name) != 0) {
+      free(search_index_name_offsets);
+      return -1;
+    }
+  free(search_index_name_offsets);
+
+  if (has_code_blocks && asset_write_to_dir_highlight_pack_js(
+                             out, asset_names.highlight_pack_js) != 0)
     return -1;
   return 0;
 }

--- a/src/multi.c
+++ b/src/multi.c
@@ -5,7 +5,61 @@
 #include <stdlib.h>
 #include <string.h>
 
+static char toc_current_page_url[] = "__MMDOC_CURRENT_PAGE_URL__";
+
+static int write_toc(FILE *page_file, const char *toc_html,
+                     const char *multipage_url) {
+  size_t placeholder_length = strlen(toc_current_page_url);
+  const char *position = toc_html;
+  const char *placeholder;
+  while ((placeholder = strstr(position, toc_current_page_url)) != NULL) {
+    size_t prefix_length = placeholder - position;
+    if (fwrite(position, 1, prefix_length, page_file) != prefix_length ||
+        fputs(multipage_url, page_file) == EOF)
+      return -1;
+    position = placeholder + placeholder_length;
+  }
+  return fputs(position, page_file) == EOF ? -1 : 0;
+}
+
+static int render_toc(Inputs inputs, AnchorLocationArray anchor_locations,
+                      char **toc_html, int *has_code_block) {
+  FILE *toc_file = tmpfile();
+  if (toc_file == NULL)
+    return -1;
+
+  *has_code_block =
+      mmdoc_render_part(inputs.toc_path, toc_file, RENDER_TYPE_MULTIPAGE, NULL,
+                        anchor_locations, toc_current_page_url, NULL);
+  if (fflush(toc_file) != 0 || fseek(toc_file, 0, SEEK_END) != 0) {
+    fclose(toc_file);
+    return -1;
+  }
+  long toc_length = ftell(toc_file);
+  if (toc_length < 0 || fseek(toc_file, 0, SEEK_SET) != 0) {
+    fclose(toc_file);
+    return -1;
+  }
+
+  *toc_html = malloc((size_t)toc_length + 1);
+  if (*toc_html == NULL) {
+    fclose(toc_file);
+    return -1;
+  }
+  size_t bytes_read = fread(*toc_html, 1, (size_t)toc_length, toc_file);
+  int read_failed = bytes_read != (size_t)toc_length || ferror(toc_file);
+  int close_failed = fclose(toc_file) != 0;
+  if (read_failed || close_failed) {
+    free(*toc_html);
+    *toc_html = NULL;
+    return -1;
+  }
+  (*toc_html)[toc_length] = '\0';
+  return 0;
+}
+
 int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
+                     const char *toc_html, int toc_has_code_block,
                      FILE *search_index_file, AnchorLocation *anchor_location,
                      AnchorLocation *prev_anchor_location,
                      AnchorLocation *next_anchor_location,
@@ -94,9 +148,11 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
   fputs("    <nav id='sidebar' class='sidebar' "
         "aria-label='Table of contents'>\n",
         page_file);
-  int has_code_block = mmdoc_render_part(
-      inputs.toc_path, page_file, RENDER_TYPE_MULTIPAGE, anchor_location,
-      anchor_locations, anchor_location->multipage_url, NULL);
+  int has_code_block = toc_has_code_block;
+  if (write_toc(page_file, toc_html, anchor_location->multipage_url) != 0) {
+    fclose(page_file);
+    return -1;
+  }
   fputs("    </nav>\n", page_file);
   fputs("    <section id='main'>\n", page_file);
   fputs("      <div id='search-panel' class='nav-search' role='search' "
@@ -124,11 +180,9 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
   fputs("      </div>\n", page_file);
   fputs("    </section>\n", page_file);
 
-  fputs("<script defer src='search_index.js'></script>\n", page_file);
   if (has_code_block)
     fputs("<script defer src='highlight.pack.js'></script>\n", page_file);
   fputs("<script defer src='mmdoc.js'></script>\n"
-        "<script defer src='fuse.basic.min.js'></script>\n"
         "<script defer src='mmdoc_search.js'></script>\n",
         page_file);
 
@@ -162,7 +216,16 @@ int mmdoc_multi(Inputs inputs, AnchorLocationArray toc_anchor_locations,
       malloc(strlen(out) + 1 + strlen(search_index_js) + 1);
   sprintf(search_index_path, "%s/%s", out, search_index_js);
   FILE *search_index_file = fopen(search_index_path, "w");
-  fputs("const corpus = [", search_index_file);
+  fputs("window.mmdocSearchCorpus = [", search_index_file);
+
+  char *toc_html = NULL;
+  int toc_has_code_block = 0;
+  if (render_toc(inputs, anchor_locations, &toc_html, &toc_has_code_block) !=
+      0) {
+    fclose(search_index_file);
+    free(search_index_path);
+    return -1;
+  }
 
   AnchorLocation *prev_anchor_location = NULL;
   AnchorLocation *next_anchor_location = NULL;
@@ -174,14 +237,22 @@ int mmdoc_multi(Inputs inputs, AnchorLocationArray toc_anchor_locations,
     } else {
       next_anchor_location = NULL;
     }
-    mmdoc_multi_page(inputs, anchor_locations, search_index_file,
-                     anchor_location, prev_anchor_location,
-                     next_anchor_location, &has_code_blocks);
+    if (mmdoc_multi_page(inputs, anchor_locations, toc_html, toc_has_code_block,
+                         search_index_file, anchor_location,
+                         prev_anchor_location, next_anchor_location,
+                         &has_code_blocks) != 0) {
+      free(toc_html);
+      fclose(search_index_file);
+      free(search_index_path);
+      return -1;
+    }
     prev_anchor_location = anchor_location;
   }
+  free(toc_html);
   fseek(search_index_file, -1, SEEK_CUR);
   fputs("]", search_index_file);
   fclose(search_index_file);
+  free(search_index_path);
   if (has_code_blocks && asset_write_to_dir_highlight_pack_js(out) != 0)
     return -1;
   return 0;

--- a/src/multi.h
+++ b/src/multi.h
@@ -6,6 +6,7 @@
 #include "types.h"
 
 int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
+                     const char *toc_html, int toc_has_code_block,
                      FILE *search_index_file, AnchorLocation *anchor_location,
                      AnchorLocation *prev_anchor_location,
                      AnchorLocation *next_anchor_location,

--- a/src/multi.h
+++ b/src/multi.h
@@ -2,12 +2,16 @@
 #pragma once
 #include <stdio.h>
 
+#include "asset.h"
 #include "inputs.h"
 #include "types.h"
 
 int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
                      const char *toc_html, int toc_has_code_block,
-                     FILE *search_index_file, AnchorLocation *anchor_location,
+                     const AssetFileNames *asset_names,
+                     const char *search_index_name, FILE *search_index_file,
+                     long *search_index_name_offset,
+                     AnchorLocation *anchor_location,
                      AnchorLocation *prev_anchor_location,
                      AnchorLocation *next_anchor_location,
                      int *has_code_blocks);

--- a/src/render.c
+++ b/src/render.c
@@ -343,33 +343,26 @@ void replace_link(cmark_node *node, char *input_file_path,
     return;
   const char *anchor = url;
 
-  AnchorLocation anchor_location;
-  int found = 0;
-  for (int i = 0; i < anchor_locations.used; i++) {
-    if (strcmp(anchor, anchor_locations.array[i].anchor) == 0) {
-      anchor_location = anchor_locations.array[i];
-      found = 1;
-      break;
-    }
-  }
-  if (!found) {
+  AnchorLocation *anchor_location =
+      find_anchor_location(&anchor_locations, anchor);
+  if (anchor_location == NULL) {
     printf("Anchor \"%s\" referenced in %s not found.\n", anchor,
            input_file_path);
     return;
   }
   if (render_type == RENDER_TYPE_MULTIPAGE) {
     char *new_url =
-        malloc(strlen(anchor_location.multipage_url) + strlen(url) + 1);
-    strcpy(new_url, anchor_location.multipage_url);
+        malloc(strlen(anchor_location->multipage_url) + strlen(url) + 1);
+    strcpy(new_url, anchor_location->multipage_url);
     strcat(new_url, url);
     cmark_node_set_url(node, new_url);
     free(new_url);
   }
-  if (strlen(anchor_location.title) != 0) {
+  if (strlen(anchor_location->title) != 0) {
     cmark_node *child = cmark_node_first_child(node);
     if (child == NULL) {
       cmark_node *new_child = cmark_node_new(CMARK_NODE_TEXT);
-      cmark_node_set_literal(new_child, anchor_location.title);
+      cmark_node_set_literal(new_child, anchor_location->title);
       cmark_node_prepend_child(node, new_child);
     }
   }

--- a/src/types.c
+++ b/src/types.c
@@ -7,10 +7,15 @@ void init_anchor_location_array(AnchorLocationArray *a, size_t initialSize) {
   a->array = malloc(initialSize * sizeof(*a->array));
   a->used = 0;
   a->size = initialSize;
+  a->anchor_index = NULL;
+  a->anchor_index_size = 0;
 }
 
 void insert_anchor_location_array(AnchorLocationArray *a,
                                   AnchorLocation *element) {
+  free(a->anchor_index);
+  a->anchor_index = NULL;
+  a->anchor_index_size = 0;
   if (a->used == a->size) {
     a->size = a->size == 0 ? 1 : a->size * 2;
     a->array = realloc(a->array, a->size * sizeof(*a->array));
@@ -19,9 +24,71 @@ void insert_anchor_location_array(AnchorLocationArray *a,
   a->used++;
 }
 
+static size_t anchor_hash(const char *anchor) {
+  size_t hash = 5381;
+  for (const unsigned char *c = (const unsigned char *)anchor; *c != '\0'; c++)
+    hash = ((hash << 5) + hash) ^ *c;
+  return hash;
+}
+
+int build_anchor_location_index(AnchorLocationArray *a) {
+  free(a->anchor_index);
+  a->anchor_index = NULL;
+  a->anchor_index_size = 0;
+
+  if (a->used == 0)
+    return 0;
+
+  size_t index_size = 1;
+  while (index_size < a->used * 2)
+    index_size *= 2;
+
+  size_t *index = calloc(index_size, sizeof(*index));
+  if (index == NULL)
+    return -1;
+
+  for (size_t i = 0; i < a->used; i++) {
+    size_t slot = anchor_hash(a->array[i].anchor) & (index_size - 1);
+    while (index[slot] != 0) {
+      size_t existing = index[slot] - 1;
+      if (strcmp(a->array[existing].anchor, a->array[i].anchor) == 0)
+        break;
+      slot = (slot + 1) & (index_size - 1);
+    }
+    if (index[slot] == 0)
+      index[slot] = i + 1;
+  }
+
+  a->anchor_index = index;
+  a->anchor_index_size = index_size;
+  return 0;
+}
+
+AnchorLocation *find_anchor_location(AnchorLocationArray *a,
+                                     const char *anchor) {
+  if (a->anchor_index != NULL) {
+    size_t slot = anchor_hash(anchor) & (a->anchor_index_size - 1);
+    while (a->anchor_index[slot] != 0) {
+      AnchorLocation *location = &a->array[a->anchor_index[slot] - 1];
+      if (strcmp(anchor, location->anchor) == 0)
+        return location;
+      slot = (slot + 1) & (a->anchor_index_size - 1);
+    }
+    return NULL;
+  }
+
+  for (size_t i = 0; i < a->used; i++)
+    if (strcmp(anchor, a->array[i].anchor) == 0)
+      return &a->array[i];
+  return NULL;
+}
+
 void free_anchor_location_array(AnchorLocationArray *a) {
+  free(a->anchor_index);
   free(a->array);
   a->array = NULL;
+  a->anchor_index = NULL;
+  a->anchor_index_size = 0;
   a->used = a->size = 0;
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -22,6 +22,8 @@ typedef struct {
   AnchorLocation *array;
   size_t used;
   size_t size;
+  size_t *anchor_index;
+  size_t anchor_index_size;
 } AnchorLocationArray;
 
 typedef struct {
@@ -31,6 +33,9 @@ typedef struct {
 void init_anchor_location_array(AnchorLocationArray *a, size_t initialSize);
 void insert_anchor_location_array(AnchorLocationArray *a,
                                   AnchorLocation *element);
+int build_anchor_location_index(AnchorLocationArray *a);
+AnchorLocation *find_anchor_location(AnchorLocationArray *a,
+                                     const char *anchor);
 void free_anchor_location_array(AnchorLocationArray *a);
 void init_array(Array *a, size_t initialSize);
 void insert_array(Array *a, char *element);

--- a/test/test.c
+++ b/test/test.c
@@ -454,6 +454,7 @@ int test_multipage_shared_assets_and_accessible_controls() {
                     "loadSearchScript('search_index.js')") &&
       file_contains(search_script_path,
                     "loadSearchScript('fuse.basic.min.js')") &&
+      file_contains(search_script_path, "typeof corpus === 'undefined'") &&
       file_contains(search_script_path, "limit: searchResultLimit");
   int page_is_accessible =
       file_contains(index_path, "class='skip-link' href='#main-content'") &&

--- a/test/test.c
+++ b/test/test.c
@@ -525,7 +525,7 @@ int test_multipage_shared_assets_and_accessible_controls() {
       file_contains(search_script_path,
                     "loadSearchScript(searchIndexSource)") &&
       file_contains(search_script_path, "loadSearchScript(fuseSource)") &&
-      file_contains(search_script_path, "typeof corpus === 'undefined'") &&
+      file_contains(search_script_path, "window.mmdocSearchCorpus") &&
       file_contains(search_script_path, "limit: searchResultLimit");
   int page_is_accessible =
       file_contains(index_path, "class='skip-link' href='#main-content'") &&

--- a/test/test.c
+++ b/test/test.c
@@ -320,6 +320,37 @@ int test_zero_capacity_arrays() {
   return 0;
 }
 
+int test_anchor_location_index() {
+  AnchorLocationArray anchor_locations;
+  init_anchor_location_array(&anchor_locations, 3);
+  AnchorLocation first = {.anchor = "#first", .title = "First"};
+  AnchorLocation second = {.anchor = "#second", .title = "Second"};
+  AnchorLocation duplicate = {.anchor = "#first", .title = "Duplicate"};
+  insert_anchor_location_array(&anchor_locations, &first);
+  insert_anchor_location_array(&anchor_locations, &second);
+  insert_anchor_location_array(&anchor_locations, &duplicate);
+
+  int build_result = build_anchor_location_index(&anchor_locations);
+  AnchorLocation *found_first =
+      find_anchor_location(&anchor_locations, "#first");
+  AnchorLocation *found_second =
+      find_anchor_location(&anchor_locations, "#second");
+  AnchorLocation *not_found =
+      find_anchor_location(&anchor_locations, "#missing");
+  int passed = build_result == 0 && found_first != NULL &&
+               strcmp(found_first->title, "First") == 0 &&
+               found_second != NULL &&
+               strcmp(found_second->title, "Second") == 0 && not_found == NULL;
+  free_anchor_location_array(&anchor_locations);
+
+  if (!passed) {
+    printf("anchor location index test failed\n");
+    return 1;
+  }
+  printf("anchor location index test passed\n");
+  return 0;
+}
+
 int file_contains(char *path, const char *expected) {
   FILE *file = fopen(path, "r");
   if (file == NULL)
@@ -406,11 +437,24 @@ int test_multipage_shared_assets_and_accessible_controls() {
     assets_found &= file_exists_and_is_not_empty(asset_path);
   }
 
-  int page_is_external = file_contains(index_path, "href='mmdoc.css'") &&
-                         file_contains(index_path, "src='mmdoc.js'") &&
-                         file_contains(index_path, "src='highlight.pack.js'") &&
-                         !file_contains(index_path, "<style>") &&
-                         !file_contains(index_path, "Highlight.js 10.7.1");
+  int page_is_external =
+      file_contains(index_path, "href='mmdoc.css'") &&
+      file_contains(index_path, "src='mmdoc.js'") &&
+      file_contains(index_path, "src='mmdoc_search.js'") &&
+      file_contains(index_path, "src='highlight.pack.js'") &&
+      !file_contains(index_path, "src='search_index.js'") &&
+      !file_contains(index_path, "src='fuse.basic.min.js'") &&
+      !file_contains(index_path, "<style>") &&
+      !file_contains(index_path, "Highlight.js 10.7.1");
+  char search_script_path[PATH_MAX];
+  snprintf(search_script_path, sizeof(search_script_path), "%s/mmdoc_search.js",
+           root);
+  int search_is_lazy =
+      file_contains(search_script_path,
+                    "loadSearchScript('search_index.js')") &&
+      file_contains(search_script_path,
+                    "loadSearchScript('fuse.basic.min.js')") &&
+      file_contains(search_script_path, "limit: searchResultLimit");
   int page_is_accessible =
       file_contains(index_path, "class='skip-link' href='#main-content'") &&
       file_contains(index_path, "aria-controls='sidebar'") &&
@@ -449,7 +493,8 @@ int test_multipage_shared_assets_and_accessible_controls() {
   rmdir(root);
 
   if (render_result != 0 || no_code_render_result != 0 || !assets_found ||
-      !page_is_external || !page_is_accessible || !highlighter_is_conditional) {
+      !page_is_external || !page_is_accessible || !search_is_lazy ||
+      !highlighter_is_conditional) {
     printf("multipage shared asset and accessibility test failed\n");
     return 1;
   }
@@ -544,8 +589,8 @@ int test_multipage_navigation_anchor() {
   init_anchor_location_array(&anchor_locations, 0);
 
   int render_result =
-      mmdoc_multi_page(inputs, anchor_locations, search_index_file, &current,
-                       &previous, &next, NULL);
+      mmdoc_multi_page(inputs, anchor_locations, "", 0, search_index_file,
+                       &current, &previous, &next, NULL);
   int found_previous = file_contains(
       page_path, "id='chapter-previous-button' class='chapter-previous' "
                  "href='./#preface'");
@@ -564,6 +609,103 @@ int test_multipage_navigation_anchor() {
     return 1;
   }
   printf("multipage navigation anchor test passed\n");
+  return 0;
+}
+
+int test_multipage_cached_toc_current_page_links() {
+  char root[] = "/tmp/mmdoc-cached-toc-test-XXXXXX";
+  if (mkdtemp(root) == NULL)
+    return 1;
+
+  char toc_path[PATH_MAX];
+  char first_source_path[PATH_MAX];
+  char second_source_path[PATH_MAX];
+  char first_output_path[PATH_MAX];
+  char second_output_path[PATH_MAX];
+  snprintf(toc_path, sizeof(toc_path), "%s/toc.md", root);
+  snprintf(first_source_path, sizeof(first_source_path), "%s/first.md", root);
+  snprintf(second_source_path, sizeof(second_source_path), "%s/second.md",
+           root);
+  snprintf(first_output_path, sizeof(first_output_path), "%s/first.html", root);
+  snprintf(second_output_path, sizeof(second_output_path), "%s/second.html",
+           root);
+
+  if (write_text_file(toc_path, "# Contents {#contents}\n\n* [](#first)\n* "
+                                "[](#second)\n") != 0 ||
+      write_text_file(first_source_path, "# First {#first}\n") != 0 ||
+      write_text_file(second_source_path, "# Second {#second}\n") != 0)
+    return 1;
+
+  Inputs inputs = {
+      .project_name = "Project",
+      .toc_path = toc_path,
+      .out_multi = root,
+  };
+  AnchorLocation first = {
+      .file_path = first_source_path,
+      .multipage_output_file_path = first_output_path,
+      .multipage_output_directory_path = root,
+      .multipage_base_href = "",
+      .multipage_url = "first/",
+      .anchor = "#first",
+      .title = "First",
+  };
+  AnchorLocation second = {
+      .file_path = second_source_path,
+      .multipage_output_file_path = second_output_path,
+      .multipage_output_directory_path = root,
+      .multipage_base_href = "",
+      .multipage_url = "second/",
+      .anchor = "#second",
+      .title = "Second",
+  };
+  AnchorLocationArray toc_anchor_locations;
+  AnchorLocationArray anchor_locations;
+  init_anchor_location_array(&toc_anchor_locations, 2);
+  init_anchor_location_array(&anchor_locations, 2);
+  insert_anchor_location_array(&toc_anchor_locations, &first);
+  insert_anchor_location_array(&toc_anchor_locations, &second);
+  insert_anchor_location_array(&anchor_locations, &first);
+  insert_anchor_location_array(&anchor_locations, &second);
+  int index_result = build_anchor_location_index(&anchor_locations);
+  int render_result =
+      mmdoc_multi(inputs, toc_anchor_locations, anchor_locations);
+
+  int links_are_page_specific =
+      file_contains(first_output_path,
+                    "<h1 id='contents'><a href='first/#contents'>") &&
+      file_contains(second_output_path,
+                    "<h1 id='contents'><a href='second/#contents'>");
+  int toc_links_are_resolved =
+      file_contains(first_output_path, "href='first/#first'") &&
+      file_contains(first_output_path, "href='second/#second'") &&
+      file_contains(second_output_path, "href='first/#first'") &&
+      file_contains(second_output_path, "href='second/#second'");
+
+  const char *asset_names[] = {
+      "a11y-dark.css",   "a11y-light.css",    "mmdoc.css",       "mmdoc.js",
+      "mmdoc_search.js", "fuse.basic.min.js", "search_index.js",
+  };
+  for (size_t i = 0; i < sizeof(asset_names) / sizeof(asset_names[0]); i++) {
+    char asset_path[PATH_MAX];
+    snprintf(asset_path, sizeof(asset_path), "%s/%s", root, asset_names[i]);
+    unlink(asset_path);
+  }
+  free_anchor_location_array(&toc_anchor_locations);
+  free_anchor_location_array(&anchor_locations);
+  unlink(first_output_path);
+  unlink(second_output_path);
+  unlink(first_source_path);
+  unlink(second_source_path);
+  unlink(toc_path);
+  rmdir(root);
+
+  if (index_result != 0 || render_result != 0 || !links_are_page_specific ||
+      !toc_links_are_resolved) {
+    printf("multipage cached TOC test failed\n");
+    return 1;
+  }
+  printf("multipage cached TOC test passed\n");
   return 0;
 }
 
@@ -649,7 +791,11 @@ int main(int argc, char *argv[]) {
   num_tests++;
   num_failed += test_zero_capacity_arrays();
   num_tests++;
+  num_failed += test_anchor_location_index();
+  num_tests++;
   num_failed += test_multipage_navigation_anchor();
+  num_tests++;
+  num_failed += test_multipage_cached_toc_current_page_links();
   num_tests++;
   num_failed += test_multipage_shared_assets_and_accessible_controls();
   num_tests++;

--- a/test/test.c
+++ b/test/test.c
@@ -6,6 +6,8 @@
 #include "../src/refs.h"
 #include "../src/render.h"
 #include "../src/single.h"
+#include <ctype.h>
+#include <dirent.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdio.h>
@@ -379,6 +381,51 @@ int file_exists_and_is_not_empty(char *path) {
   return first != EOF;
 }
 
+int find_asset_name(char *dir, const char *prefix, const char *suffix,
+                    char *result, size_t result_size) {
+  DIR *directory = opendir(dir);
+  if (directory == NULL)
+    return 0;
+  struct dirent *entry;
+  int found = 0;
+  while ((entry = readdir(directory)) != NULL) {
+    size_t name_length = strlen(entry->d_name);
+    size_t prefix_length = strlen(prefix);
+    size_t suffix_length = strlen(suffix);
+    if (name_length >= prefix_length + suffix_length &&
+        strncmp(entry->d_name, prefix, prefix_length) == 0 &&
+        strcmp(entry->d_name + name_length - suffix_length, suffix) == 0) {
+      snprintf(result, result_size, "%s", entry->d_name);
+      found = 1;
+      break;
+    }
+  }
+  closedir(directory);
+  return found;
+}
+
+int asset_name_has_hash(const char *file_name, const char *stem,
+                        const char *extension) {
+  size_t stem_length = strlen(stem);
+  size_t extension_length = strlen(extension);
+  size_t expected_length = stem_length + 1 + 16 + 1 + extension_length;
+  if (strlen(file_name) != expected_length ||
+      strncmp(file_name, stem, stem_length) != 0 ||
+      file_name[stem_length] != '.' ||
+      strcmp(file_name + expected_length - extension_length, extension) != 0)
+    return 0;
+  for (size_t i = stem_length + 1; i < stem_length + 17; i++)
+    if (!isxdigit((unsigned char)file_name[i]))
+      return 0;
+  return file_name[stem_length + 17] == '.';
+}
+
+void unlink_asset(char *dir, const char *file_name) {
+  char path[PATH_MAX];
+  snprintf(path, sizeof(path), "%s/%s", dir, file_name);
+  unlink(path);
+}
+
 int write_text_file(char *path, const char *contents) {
   FILE *file = fopen(path, "w");
   if (file == NULL)
@@ -425,35 +472,59 @@ int test_multipage_shared_assets_and_accessible_controls() {
 
   int render_result =
       mmdoc_multi(inputs, toc_anchor_locations, anchor_locations);
+  AssetFileNames generated_names;
+  asset_file_names(&generated_names);
+  char search_index_name[ASSET_FILE_NAME_SIZE] = "";
+  int search_index_found =
+      find_asset_name(root, "search_index.", ".js", search_index_name,
+                      sizeof(search_index_name));
+  char first_search_index_name[ASSET_FILE_NAME_SIZE];
+  snprintf(first_search_index_name, sizeof(first_search_index_name), "%s",
+           search_index_name);
   const char *asset_names[] = {
-      "a11y-dark.css",     "a11y-light.css",  "mmdoc.css",
-      "mmdoc.js",          "mmdoc_search.js", "fuse.basic.min.js",
-      "highlight.pack.js", "search_index.js",
+      generated_names.a11y_dark_css,     generated_names.a11y_light_css,
+      generated_names.mmdoc_css,         generated_names.mmdoc_js,
+      generated_names.mmdoc_search_js,   generated_names.fuse_basic_min_js,
+      generated_names.highlight_pack_js,
   };
-  int assets_found = 1;
+  int assets_found = search_index_found;
   for (size_t i = 0; i < sizeof(asset_names) / sizeof(asset_names[0]); i++) {
     char asset_path[PATH_MAX];
     snprintf(asset_path, sizeof(asset_path), "%s/%s", root, asset_names[i]);
     assets_found &= file_exists_and_is_not_empty(asset_path);
   }
 
+  int names_are_hashed =
+      asset_name_has_hash(generated_names.a11y_dark_css, "a11y-dark", "css") &&
+      asset_name_has_hash(generated_names.a11y_light_css, "a11y-light",
+                          "css") &&
+      asset_name_has_hash(generated_names.mmdoc_css, "mmdoc", "css") &&
+      asset_name_has_hash(generated_names.mmdoc_js, "mmdoc", "js") &&
+      asset_name_has_hash(generated_names.mmdoc_search_js, "mmdoc_search",
+                          "js") &&
+      asset_name_has_hash(generated_names.fuse_basic_min_js, "fuse.basic.min",
+                          "js") &&
+      asset_name_has_hash(generated_names.highlight_pack_js, "highlight.pack",
+                          "js") &&
+      asset_name_has_hash(search_index_name, "search_index", "js");
   int page_is_external =
-      file_contains(index_path, "href='mmdoc.css'") &&
-      file_contains(index_path, "src='mmdoc.js'") &&
-      file_contains(index_path, "src='mmdoc_search.js'") &&
-      file_contains(index_path, "src='highlight.pack.js'") &&
-      !file_contains(index_path, "src='search_index.js'") &&
-      !file_contains(index_path, "src='fuse.basic.min.js'") &&
+      file_contains(index_path, generated_names.mmdoc_css) &&
+      file_contains(index_path, generated_names.mmdoc_js) &&
+      file_contains(index_path, generated_names.mmdoc_search_js) &&
+      file_contains(index_path, generated_names.highlight_pack_js) &&
+      file_contains(index_path, search_index_name) &&
+      file_contains(index_path, generated_names.fuse_basic_min_js) &&
+      !file_contains(index_path, "href='mmdoc.css'") &&
+      !file_contains(index_path, "src='mmdoc.js'") &&
       !file_contains(index_path, "<style>") &&
       !file_contains(index_path, "Highlight.js 10.7.1");
   char search_script_path[PATH_MAX];
-  snprintf(search_script_path, sizeof(search_script_path), "%s/mmdoc_search.js",
-           root);
+  snprintf(search_script_path, sizeof(search_script_path), "%s/%s", root,
+           generated_names.mmdoc_search_js);
   int search_is_lazy =
       file_contains(search_script_path,
-                    "loadSearchScript('search_index.js')") &&
-      file_contains(search_script_path,
-                    "loadSearchScript('fuse.basic.min.js')") &&
+                    "loadSearchScript(searchIndexSource)") &&
+      file_contains(search_script_path, "loadSearchScript(fuseSource)") &&
       file_contains(search_script_path, "typeof corpus === 'undefined'") &&
       file_contains(search_script_path, "limit: searchResultLimit");
   int page_is_accessible =
@@ -464,26 +535,30 @@ int test_multipage_shared_assets_and_accessible_controls() {
       file_contains(index_path, "<main id='main-content' tabindex='-1'>");
 
   for (size_t i = 0; i < sizeof(asset_names) / sizeof(asset_names[0]); i++) {
-    char asset_path[PATH_MAX];
-    snprintf(asset_path, sizeof(asset_path), "%s/%s", root, asset_names[i]);
-    unlink(asset_path);
+    unlink_asset(root, asset_names[i]);
   }
+  unlink_asset(root, search_index_name);
   int no_code_render_result = 1;
   int highlighter_is_conditional = 0;
+  int corpus_hash_changed = 0;
   if (write_text_file(page_path, "# Page {#page}\n") == 0) {
     no_code_render_result =
         mmdoc_multi(inputs, toc_anchor_locations, anchor_locations);
     char highlighter_path[PATH_MAX];
-    snprintf(highlighter_path, sizeof(highlighter_path), "%s/highlight.pack.js",
-             root);
+    snprintf(highlighter_path, sizeof(highlighter_path), "%s/%s", root,
+             generated_names.highlight_pack_js);
     highlighter_is_conditional =
         !file_exists_and_is_not_empty(highlighter_path) &&
-        !file_contains(index_path, "src='highlight.pack.js'");
+        !file_contains(index_path, generated_names.highlight_pack_js);
   }
   for (size_t i = 0; i < sizeof(asset_names) / sizeof(asset_names[0]); i++) {
-    char asset_path[PATH_MAX];
-    snprintf(asset_path, sizeof(asset_path), "%s/%s", root, asset_names[i]);
-    unlink(asset_path);
+    unlink_asset(root, asset_names[i]);
+  }
+  if (find_asset_name(root, "search_index.", ".js", search_index_name,
+                      sizeof(search_index_name))) {
+    corpus_hash_changed =
+        strcmp(first_search_index_name, search_index_name) != 0;
+    unlink_asset(root, search_index_name);
   }
 
   free_anchor_location_array(&toc_anchor_locations);
@@ -494,8 +569,8 @@ int test_multipage_shared_assets_and_accessible_controls() {
   rmdir(root);
 
   if (render_result != 0 || no_code_render_result != 0 || !assets_found ||
-      !page_is_external || !page_is_accessible || !search_is_lazy ||
-      !highlighter_is_conditional) {
+      !names_are_hashed || !page_is_external || !page_is_accessible ||
+      !search_is_lazy || !corpus_hash_changed || !highlighter_is_conditional) {
     printf("multipage shared asset and accessibility test failed\n");
     return 1;
   }
@@ -588,10 +663,13 @@ int test_multipage_navigation_anchor() {
   };
   AnchorLocationArray anchor_locations;
   init_anchor_location_array(&anchor_locations, 0);
+  AssetFileNames generated_names;
+  asset_file_names(&generated_names);
 
   int render_result =
-      mmdoc_multi_page(inputs, anchor_locations, "", 0, search_index_file,
-                       &current, &previous, &next, NULL);
+      mmdoc_multi_page(inputs, anchor_locations, "", 0, &generated_names,
+                       "search_index.0000000000000000.js", search_index_file,
+                       NULL, &current, &previous, &next, NULL);
   int found_previous = file_contains(
       page_path, "id='chapter-previous-button' class='chapter-previous' "
                  "href='./#preface'");
@@ -683,15 +761,20 @@ int test_multipage_cached_toc_current_page_links() {
       file_contains(second_output_path, "href='first/#first'") &&
       file_contains(second_output_path, "href='second/#second'");
 
+  AssetFileNames generated_names;
+  asset_file_names(&generated_names);
   const char *asset_names[] = {
-      "a11y-dark.css",   "a11y-light.css",    "mmdoc.css",       "mmdoc.js",
-      "mmdoc_search.js", "fuse.basic.min.js", "search_index.js",
+      generated_names.a11y_dark_css,   generated_names.a11y_light_css,
+      generated_names.mmdoc_css,       generated_names.mmdoc_js,
+      generated_names.mmdoc_search_js, generated_names.fuse_basic_min_js,
   };
   for (size_t i = 0; i < sizeof(asset_names) / sizeof(asset_names[0]); i++) {
-    char asset_path[PATH_MAX];
-    snprintf(asset_path, sizeof(asset_path), "%s/%s", root, asset_names[i]);
-    unlink(asset_path);
+    unlink_asset(root, asset_names[i]);
   }
+  char search_index_name[ASSET_FILE_NAME_SIZE];
+  if (find_asset_name(root, "search_index.", ".js", search_index_name,
+                      sizeof(search_index_name)))
+    unlink_asset(root, search_index_name);
   free_anchor_location_array(&toc_anchor_locations);
   free_anchor_location_array(&anchor_locations);
   unlink(first_output_path);


### PR DESCRIPTION
## Summary

- load Fuse and the generated search corpus only when search is opened
- limit rendered search results to 50 and report loading failures accessibly
- fingerprint generated CSS, JavaScript, highlighting, Fuse, and search corpus filenames from their contents
- pass fingerprinted lazy-search asset names through script data attributes
- render the multipage table of contents once while preserving page-specific links
- index anchors for constant-time TOC and document link resolution
- document and test the fingerprinted output layout

## Performance and caching

- reduces the measured initial gzip payload of a no-code documentation page from 16.6 KB to 9.4 KB
- reduces multipage TOC parsing from once per page to once per build
- replaces repeated linear anchor scans with hash lookups
- gives changed assets new URLs while keeping unchanged asset URLs stable for long-lived browser caches

## Testing

- nix develop -c meson test -C build-normal --print-errorlogs
- nix develop -c clang-format --dry-run --Werror src/asset.h src/asset.c src/types.h src/types.c src/anchors.c src/render.c src/multi.h src/multi.c test/test.c
- nix build --no-link .#mmdoc
- git diff --check
- verified with headless Chrome that the fingerprinted lazy corpus and Fuse assets load and return search results