### PR TITLE
Fix Nixpkgs manual markup rendering

### DIFF
--- a/src/anchors.c
+++ b/src/anchors.c
@@ -7,54 +7,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-enum ref_parse_state { NONE, L, REF };
-
 int mmdoc_anchors(Array *md_anchors, char *path) {
-  char ref[1024];
-  size_t refpos = 0;
-  FILE *file = fopen(path, "r");
-  if (file == NULL) {
-    fprintf(stderr, "Error opening %s: %s\n", path, strerror(errno));
-    return 1;
-  }
-  int c;
-  enum ref_parse_state state = NONE;
-
-  while (1) {
-    c = fgetc(file);
-    if (c == EOF)
-      break;
-    if (state == NONE && c == '{') {
-      state = L;
-      continue;
-    }
-    if (state == L && c == '#') {
-      state = REF;
-      ref[refpos] = c;
-      refpos += 1;
-      continue;
-    }
-    if (state == REF && (c == '\n' || c == '\r')) {
-    } else if (state == REF && c != '}') {
-      if (refpos >= sizeof(ref) - 1) {
-        fprintf(stderr, "Anchor in %s exceeds %zu bytes.\n", path,
-                sizeof(ref) - 1);
-        fclose(file);
-        return 1;
-      }
-      ref[refpos] = c;
-      refpos += 1;
-      continue;
-    } else if (state == REF && c == '}') {
-      ref[refpos] = '\0';
-      insert_array(md_anchors, ref);
-    }
-    refpos = 0;
-    state = NONE;
-    continue;
-  }
-  fclose(file);
-  return 0;
+  return mmdoc_render_collect_anchors(path, md_anchors);
 }
 
 int mmdoc_anchors_locations(AnchorLocationArray *anchor_locations,

--- a/src/multi.c
+++ b/src/multi.c
@@ -141,8 +141,9 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
         "  </head>\n"
         "  <body>\n",
         page_file);
-  fputs("  <a class='skip-link' href='#main-content'>Skip to main "
-        "content</a>\n"
+  fputs("  <a class='skip-link' href='", page_file);
+  fputs(anchor_location->multipage_url, page_file);
+  fputs("#main-content'>Skip to main content</a>\n"
         "  <input type='checkbox' id='sidebar-checkbox' aria-hidden='true' "
         "tabindex='-1' style='display: none;'>\n",
         page_file);
@@ -338,8 +339,7 @@ int mmdoc_multi(Inputs inputs, AnchorLocationArray toc_anchor_locations,
     AnchorLocation *anchor_location =
         &toc_anchor_locations.array[page_indices[i]];
     if (i + 1 < page_count) {
-      next_anchor_location =
-          &toc_anchor_locations.array[page_indices[i + 1]];
+      next_anchor_location = &toc_anchor_locations.array[page_indices[i + 1]];
     } else {
       next_anchor_location = NULL;
     }
@@ -358,8 +358,8 @@ int mmdoc_multi(Inputs inputs, AnchorLocationArray toc_anchor_locations,
     prev_anchor_location = anchor_location;
   }
   free(toc_html);
-  int search_index_failed = page_count > 0 &&
-                            fseek(search_index_file, -1, SEEK_CUR) != 0;
+  int search_index_failed =
+      page_count > 0 && fseek(search_index_file, -1, SEEK_CUR) != 0;
   if (!search_index_failed && fputs("]", search_index_file) == EOF)
     search_index_failed = 1;
   if (fclose(search_index_file) != 0)
@@ -393,11 +393,10 @@ int mmdoc_multi(Inputs inputs, AnchorLocationArray toc_anchor_locations,
   free(search_index_path);
 
   for (size_t i = 0; i < page_count; i++) {
-    if (replace_file_name(
-            toc_anchor_locations.array[page_indices[i]]
-                .multipage_output_file_path,
-            search_index_name_offsets[i], search_index_placeholder,
-            search_index_name) != 0) {
+    if (replace_file_name(toc_anchor_locations.array[page_indices[i]]
+                              .multipage_output_file_path,
+                          search_index_name_offsets[i],
+                          search_index_placeholder, search_index_name) != 0) {
       free(page_indices);
       free(search_index_name_offsets);
       return -1;

--- a/src/parse.c
+++ b/src/parse.c
@@ -256,9 +256,10 @@ int parse_dd(const char *text) {
       state = DD_SPACE;
       continue;
     }
-    if (state == DD_SPACE && text[i] != ' ') {
+    if (state == DD_SPACE && text[i] == ' ')
+      continue;
+    if (state == DD_SPACE)
       return i;
-    }
     return -1;
   }
   return -1;

--- a/src/render.c
+++ b/src/render.c
@@ -178,6 +178,62 @@ int replace_link_bracket_with_span(cmark_node *node) {
   return 1;
 }
 
+int replace_code_link_bracket_with_span(cmark_node *node) {
+  if (cmark_node_get_type(node) != CMARK_NODE_CODE)
+    return 0;
+
+  cmark_node *previous = cmark_node_previous(node);
+  cmark_node *next = cmark_node_next(node);
+  if (previous == NULL || next == NULL ||
+      cmark_node_get_type(previous) != CMARK_NODE_TEXT ||
+      cmark_node_get_type(next) != CMARK_NODE_TEXT)
+    return 0;
+
+  const char *left = cmark_node_get_literal(previous);
+  const char *right = cmark_node_get_literal(next);
+  size_t left_length = strlen(left);
+  if (left_length == 0 || left[left_length - 1] != '[' ||
+      strncmp(right, "]{#", 3) != 0)
+    return 0;
+
+  const char *anchor_end = strchr(right + 3, '}');
+  if (anchor_end == NULL || anchor_end == right + 3)
+    return 0;
+
+  size_t anchor_length = (size_t)(anchor_end - (right + 3));
+  char *start = malloc(strlen("<span id=''></span>") + anchor_length + 1);
+  if (start == NULL)
+    return 0;
+  snprintf(start, strlen("<span id=''></span>") + anchor_length + 1,
+           "<span id='%.*s'>", (int)anchor_length, right + 3);
+
+  char *new_left = malloc(left_length);
+  char *new_right = malloc(strlen(anchor_end + 1) + 1);
+  if (new_left == NULL || new_right == NULL) {
+    free(start);
+    free(new_left);
+    free(new_right);
+    return 0;
+  }
+  memcpy(new_left, left, left_length - 1);
+  new_left[left_length - 1] = '\0';
+  strcpy(new_right, anchor_end + 1);
+  cmark_node_set_literal(previous, new_left);
+  cmark_node_set_literal(next, new_right);
+
+  cmark_node *start_node = cmark_node_new(CMARK_NODE_HTML_INLINE);
+  cmark_node_set_literal(start_node, start);
+  cmark_node_insert_before(node, start_node);
+  cmark_node *end_node = cmark_node_new(CMARK_NODE_HTML_INLINE);
+  cmark_node_set_literal(end_node, "</span>");
+  cmark_node_insert_after(node, end_node);
+
+  free(start);
+  free(new_left);
+  free(new_right);
+  return 1;
+}
+
 int replace_admonition_start(char *multipage_url, cmark_node *node) {
   const char *lit = cmark_node_get_literal(node);
   char *admonition_type = malloc(strlen(lit) + 1);
@@ -245,99 +301,143 @@ int replace_admonition_end(cmark_node *node) {
   return 1;
 }
 
-int replace_dd(cmark_node *node) {
-  const char *lit = cmark_node_get_literal(node);
-  int pos = parse_dd(lit);
-  if (-1 == pos)
-    return 0;
+static cmark_node *new_html_block(const char *literal) {
+  cmark_node *node = cmark_node_new(CMARK_NODE_HTML_BLOCK);
+  cmark_node_set_literal(node, literal);
+  return node;
+}
 
-  cmark_node *parent = cmark_node_parent(node);
-  parent = cmark_node_previous(parent);
-  if (parent == NULL)
-    return 0;
+static int definition_position_for_text_node(cmark_node *node) {
+  if (node == NULL || cmark_node_get_type(node) != CMARK_NODE_TEXT)
+    return -1;
+  const char *literal = cmark_node_get_literal(node);
+  int position = parse_dd(literal);
+  if (position != -1)
+    return position;
 
-  cmark_node *new_node = NULL;
-  cmark_node *previous = NULL;
+  size_t i = 0;
+  while (literal[i] == ' ')
+    i++;
+  if (literal[i] != ':')
+    return -1;
+  i++;
+  if (literal[i] != ' ')
+    return -1;
+  while (literal[i] == ' ')
+    i++;
+  return literal[i] == '\0' && cmark_node_next(node) != NULL ? (int)i : -1;
+}
 
-  new_node = cmark_node_new(CMARK_NODE_HTML_BLOCK);
-  cmark_node_set_literal(new_node, "<dl>");
-  cmark_node_insert_before(parent, new_node);
+static int paragraph_definition_position(cmark_node *node) {
+  if (node == NULL || cmark_node_get_type(node) != CMARK_NODE_PARAGRAPH)
+    return -1;
+  cmark_node *child = cmark_node_first_child(node);
+  return definition_position_for_text_node(child);
+}
 
+static void split_compact_definition_paragraph(cmark_node *paragraph) {
+  cmark_node *current = paragraph;
   for (;;) {
-    if (parent == NULL)
-      break;
-
-    cmark_node *child = cmark_node_first_child(parent);
-    lit = cmark_node_get_literal(child);
-    pos = parse_dd(lit);
-    if (pos != -1) {
-      new_node = cmark_node_new(CMARK_NODE_HTML_BLOCK);
-      cmark_node_set_literal(new_node, "<dd>");
-      cmark_node_insert_before(parent, new_node);
-
-      new_node = cmark_node_new(CMARK_NODE_HTML_BLOCK);
-      cmark_node_set_literal(new_node, "</dd>");
-      cmark_node_insert_after(parent, new_node);
-
-      cmark_node_set_literal(child, lit + pos);
-
-      previous = parent;
-      parent = cmark_node_next(parent);
-      previous = parent;
-      parent = cmark_node_next(parent);
-      continue;
+    cmark_node *line_break = cmark_node_first_child(current);
+    while (line_break != NULL) {
+      cmark_node *next = cmark_node_next(line_break);
+      if (cmark_node_get_type(line_break) == CMARK_NODE_SOFTBREAK &&
+          next != NULL && cmark_node_get_type(next) == CMARK_NODE_TEXT &&
+          definition_position_for_text_node(next) != -1)
+        break;
+      line_break = next;
     }
-    previous = parent;
-    parent = cmark_node_next(parent);
-    if (parent == NULL)
-      break;
+    if (line_break == NULL)
+      return;
 
-    child = cmark_node_first_child(parent);
-    lit = cmark_node_get_literal(child);
-    pos = parse_dd(lit);
-    if (pos != -1) {
-      new_node = cmark_node_new(CMARK_NODE_HTML_BLOCK);
-      cmark_node_set_literal(new_node, "<dt>");
-      cmark_node_insert_before(previous, new_node);
-
-      new_node = cmark_node_new(CMARK_NODE_HTML_BLOCK);
-      cmark_node_set_literal(new_node, "</dt>");
-      cmark_node_insert_after(previous, new_node);
-
-      new_node = cmark_node_new(CMARK_NODE_HTML_BLOCK);
-      cmark_node_set_literal(new_node, "<dd>");
-      cmark_node_insert_before(parent, new_node);
-
-      new_node = cmark_node_new(CMARK_NODE_HTML_BLOCK);
-      cmark_node_set_literal(new_node, "</dd>");
-      cmark_node_insert_after(parent, new_node);
-
-      cmark_node_set_literal(child, lit + pos);
-
-      previous = parent;
-      parent = cmark_node_next(parent);
-      previous = parent;
-      parent = cmark_node_next(parent);
-      continue;
+    cmark_node *definition = cmark_node_new(CMARK_NODE_PARAGRAPH);
+    cmark_node_insert_after(current, definition);
+    cmark_node *child = cmark_node_next(line_break);
+    while (child != NULL) {
+      cmark_node *next = cmark_node_next(child);
+      cmark_node_unlink(child);
+      cmark_node_append_child(definition, child);
+      child = next;
     }
-    break;
+    cmark_node_unlink(line_break);
+    cmark_node_free(line_break);
+    current = definition;
   }
+}
 
-  new_node = cmark_node_new(CMARK_NODE_HTML_BLOCK);
-  cmark_node_set_literal(new_node, "</dl>");
-  cmark_node_insert_before(previous, new_node);
+static void normalize_compact_definition_lists(cmark_node *container) {
+  for (cmark_node *child = cmark_node_first_child(container); child != NULL;) {
+    cmark_node *next = cmark_node_next(child);
+    if (cmark_node_get_type(child) == CMARK_NODE_PARAGRAPH)
+      split_compact_definition_paragraph(child);
+    else
+      normalize_compact_definition_lists(child);
+    child = next;
+  }
+}
 
-  return 1;
+static void wrap_block(cmark_node *node, const char *start, const char *end) {
+  cmark_node *start_node = new_html_block(start);
+  cmark_node *end_node = new_html_block(end);
+  cmark_node_insert_before(node, start_node);
+  cmark_node_insert_after(node, end_node);
+}
+
+static void rewrite_definition_lists_in(cmark_node *container) {
+  cmark_node *cursor = cmark_node_first_child(container);
+  while (cursor != NULL) {
+    cmark_node *first_definition = cmark_node_next(cursor);
+    if (cmark_node_get_type(cursor) != CMARK_NODE_PARAGRAPH ||
+        paragraph_definition_position(first_definition) == -1) {
+      rewrite_definition_lists_in(cursor);
+      cursor = cmark_node_next(cursor);
+      continue;
+    }
+
+    cmark_node *open = new_html_block("<dl>");
+    cmark_node_insert_before(cursor, open);
+    for (;;) {
+      cmark_node *definition = cmark_node_next(cursor);
+      wrap_block(cursor, "<dt>", "</dt>");
+      cursor = definition;
+
+      while (paragraph_definition_position(cursor) != -1) {
+        cmark_node *next = cmark_node_next(cursor);
+        cmark_node *first_child = cmark_node_first_child(cursor);
+        const char *literal = cmark_node_get_literal(first_child);
+        int position = definition_position_for_text_node(first_child);
+        cmark_node_set_literal(first_child, literal + position);
+        wrap_block(cursor, "<dd>", "</dd>");
+        cursor = next;
+      }
+
+      if (cursor == NULL ||
+          cmark_node_get_type(cursor) != CMARK_NODE_PARAGRAPH ||
+          paragraph_definition_position(cmark_node_next(cursor)) == -1)
+        break;
+    }
+
+    cmark_node *close = new_html_block("</dl>");
+    if (cursor == NULL)
+      cmark_node_append_child(container, close);
+    else
+      cmark_node_insert_before(cursor, close);
+  }
+}
+
+static void rewrite_definition_lists(cmark_node *document) {
+  normalize_compact_definition_lists(document);
+  rewrite_definition_lists_in(document);
 }
 
 void replace_link(cmark_node *node, char *input_file_path,
-                  AnchorLocationArray anchor_locations,
-                  render_type render_type) {
+                  AnchorLocationArray anchor_locations, render_type render_type,
+                  char *multipage_url) {
   if (render_type == RENDER_TYPE_SINGLE) {
     return;
   }
   const char *url = cmark_node_get_url(node);
-  if (strlen(url) < 2)
+  if (strlen(url) == 0)
     return;
   if (url[0] != '#')
     return;
@@ -348,6 +448,13 @@ void replace_link(cmark_node *node, char *input_file_path,
   if (anchor_location == NULL) {
     printf("Anchor \"%s\" referenced in %s not found.\n", anchor,
            input_file_path);
+    if (render_type == RENDER_TYPE_MULTIPAGE) {
+      char *new_url = malloc(strlen(multipage_url) + strlen(url) + 1);
+      strcpy(new_url, multipage_url);
+      strcat(new_url, url);
+      cmark_node_set_url(node, new_url);
+      free(new_url);
+    }
     return;
   }
   if (render_type == RENDER_TYPE_MULTIPAGE) {
@@ -418,6 +525,27 @@ int cmark_rewrite_syntax(cmark_node *document, cmark_mem *mem,
   return has_code_block;
 }
 
+void cmark_rewrite_spans(cmark_node *document) {
+  int changed;
+  do {
+    changed = 0;
+    cmark_iter *iter = cmark_iter_new(document);
+    cmark_event_type event;
+    while ((event = cmark_iter_next(iter)) != CMARK_EVENT_DONE) {
+      if (event != CMARK_EVENT_ENTER)
+        continue;
+      cmark_node *node = cmark_iter_get_node(iter);
+      if (replace_code_link_bracket_with_span(node) ||
+          (cmark_node_get_type(node) == CMARK_NODE_TEXT &&
+           replace_link_bracket_with_span(node))) {
+        changed = 1;
+        break;
+      }
+    }
+    cmark_iter_free(iter);
+  } while (changed);
+}
+
 void cmark_rewrite(cmark_node *document, cmark_mem *mem, char *input_file_path,
                    render_type render_type, char *multipage_url,
                    AnchorLocationArray anchor_locations) {
@@ -439,18 +567,15 @@ void cmark_rewrite(cmark_node *document, cmark_mem *mem, char *input_file_path,
       node = cmark_iter_get_node(iter);
       type = cmark_node_get_type(node);
       if (type == CMARK_NODE_LINK) {
-        replace_link(node, input_file_path, anchor_locations, render_type);
+        replace_link(node, input_file_path, anchor_locations, render_type,
+                     multipage_url);
         continue;
       }
       if (type != CMARK_NODE_TEXT)
         continue;
-      if (replace_link_bracket_with_span(node))
-        continue;
       if (replace_admonition_start(multipage_url, node))
         continue;
       if (replace_admonition_end(node))
-        continue;
-      if (replace_dd(node))
         continue;
     }
     if (CMARK_EVENT_DONE == event)
@@ -562,6 +687,69 @@ cmark_node *mmdoc_render_cmark_document(char *file_path, cmark_parser *parser) {
   return cmark_parser_finish(parser);
 }
 
+static int collect_anchors_from_text(Array *anchors, const char *text,
+                                     const char *file_path) {
+  for (size_t i = 0; text[i] != '\0'; i++) {
+    if (text[i] != '{')
+      continue;
+    size_t close = i + 1;
+    while (text[close] != '\0' && text[close] != '}')
+      close++;
+    if (text[close] != '}')
+      continue;
+
+    size_t hash = i + 1;
+    while (hash < close && text[hash] != '#')
+      hash++;
+    if (hash == close)
+      continue;
+
+    size_t end = hash + 1;
+    while (end < close && !isspace((unsigned char)text[end]))
+      end++;
+    size_t anchor_length = end - hash;
+    if (anchor_length <= 1)
+      continue;
+    if (anchor_length >= 1024) {
+      fprintf(stderr, "Anchor in %s exceeds 1023 bytes.\n", file_path);
+      return -1;
+    }
+    char anchor[1024];
+    memcpy(anchor, text + hash, anchor_length);
+    anchor[anchor_length] = '\0';
+    insert_array(anchors, anchor);
+    i = close;
+  }
+  return 0;
+}
+
+int mmdoc_render_collect_anchors(char *file_path, Array *anchors) {
+  cmark_mem *mem = cmark_get_default_mem_allocator();
+  cmark_parser *parser =
+      cmark_parser_new_with_mem(mmdoc_render_cmark_options, mem);
+  cmark_node *document = mmdoc_render_cmark_document(file_path, parser);
+  if (document == NULL) {
+    cmark_parser_free(parser);
+    return -1;
+  }
+
+  int failed = 0;
+  cmark_iter *iter = cmark_iter_new(document);
+  cmark_event_type event;
+  while (!failed && (event = cmark_iter_next(iter)) != CMARK_EVENT_DONE) {
+    if (event != CMARK_EVENT_ENTER)
+      continue;
+    cmark_node *node = cmark_iter_get_node(iter);
+    if (cmark_node_get_type(node) == CMARK_NODE_TEXT)
+      failed = collect_anchors_from_text(anchors, cmark_node_get_literal(node),
+                                         file_path) != 0;
+  }
+  cmark_iter_free(iter);
+  cmark_node_free(document);
+  cmark_parser_free(parser);
+  return failed ? -1 : 0;
+}
+
 int mmdoc_render_part(char *file_path, FILE *output_file,
                       render_type render_type, AnchorLocation *anchor_location,
                       AnchorLocationArray anchor_locations, char *multipage_url,
@@ -577,6 +765,9 @@ int mmdoc_render_part(char *file_path, FILE *output_file,
 
   int has_code_block = cmark_rewrite_syntax(document, mem, file_path,
                                             render_type, anchor_locations);
+
+  cmark_rewrite_spans(document);
+  rewrite_definition_lists(document);
 
   cmark_rewrite(document, mem, file_path, render_type, multipage_url,
                 anchor_locations);

--- a/src/render.h
+++ b/src/render.h
@@ -16,3 +16,5 @@ int mmdoc_render_part(char *file_path, FILE *output_file,
                       FILE *search_index_path);
 
 char *mmdoc_render_get_title_from_file(char *file_path);
+
+int mmdoc_render_collect_anchors(char *file_path, Array *anchors);

--- a/test/example/e013/expected.html
+++ b/test/example/e013/expected.html
@@ -1,0 +1,23 @@
+<dl>
+<dt>
+<p>Options</p>
+</dt>
+<dd>
+<p>Empty set, there may be configuration options in the future</p>
+</dd>
+<dt>
+<p><code>v</code></p>
+</dt>
+<dd>
+<p>2. Function argument</p>
+</dd>
+<dt>
+<p>Structured function argument</p>
+</dt>
+<dd>
+<p><code>mkValueString</code> (optional, default: <code>mkValueStringDefault {}</code>)</p>
+</dd>
+<dd>
+<p>Function to convert values to strings</p>
+</dd>
+</dl>

--- a/test/example/e013/input.md
+++ b/test/example/e013/input.md
@@ -1,0 +1,9 @@
+Options
+: Empty set, there may be configuration options in the future
+
+`v`
+: 2. Function argument
+
+Structured function argument
+: `mkValueString` (optional, default: `mkValueStringDefault {}`)
+: Function to convert values to strings

--- a/test/example/e014/expected.html
+++ b/test/example/e014/expected.html
@@ -1,0 +1,2 @@
+<p><span id='lib-anchor'><code>lib</code></span></p>
+<p><span id='first-alias'></span> <span id='second-alias'></span></p>

--- a/test/example/e014/input.md
+++ b/test/example/e014/input.md
@@ -1,0 +1,3 @@
+[`lib`]{#lib-anchor}
+
+[]{#first-alias} []{#second-alias}

--- a/test/example/e015/expected.html
+++ b/test/example/e015/expected.html
@@ -1,0 +1,1 @@
+<p><a href="/#missing">missing anchor</a></p>

--- a/test/example/e015/input.md
+++ b/test/example/e015/input.md
@@ -1,0 +1,1 @@
+[missing anchor](#missing)

--- a/test/example/e016/expected.html
+++ b/test/example/e016/expected.html
@@ -1,0 +1,14 @@
+<dl>
+<dt>
+<p><code>name</code> (String)</p>
+</dt>
+<dd>
+<p>The derivation's name.</p>
+</dd>
+<dt>
+<p><code>runLocal</code> (Boolean)</p>
+</dt>
+<dd>
+<p>Build locally.</p>
+</dd>
+</dl>

--- a/test/example/e016/input.md
+++ b/test/example/e016/input.md
@@ -1,0 +1,5 @@
+`name` (String)
+:   The derivation's name.
+
+`runLocal` (Boolean)
+:   Build locally.

--- a/test/test.c
+++ b/test/test.c
@@ -209,6 +209,14 @@ int test_e007() {
   return retval;
 }
 
+int test_e015() {
+  AnchorLocationArray anchor_locations;
+  init_anchor_location_array(&anchor_locations, 0);
+  int retval = test_multipage_render("e015", anchor_locations);
+  free_anchor_location_array(&anchor_locations);
+  return retval;
+}
+
 int test_title(char *example, char *expected_title) {
   char *example_dir = TEST_EXAMPLE_DIR;
   char *input_filename = "input.md";
@@ -350,6 +358,40 @@ int test_anchor_location_index() {
     return 1;
   }
   printf("anchor location index test passed\n");
+  return 0;
+}
+
+int test_anchor_discovery_uses_markdown_ast() {
+  char path[] = "/tmp/mmdoc-anchor-discovery-XXXXXX.md";
+  int fd = mkstemps(path, 3);
+  if (fd == -1)
+    return 1;
+  FILE *file = fdopen(fd, "w");
+  if (file == NULL)
+    return 1;
+  const char *markdown = "# Page {#page}\n\n"
+                         "`{#not-an-anchor}`\n\n"
+                         "::: {.example #example-anchor}\nExample\n:::\n\n"
+                         "[`lib`]{#lib-anchor}\n\n"
+                         "[]{#first-alias} []{#second-alias}\n";
+  int write_failed = fputs(markdown, file) == EOF || fclose(file) != 0;
+
+  Array anchors;
+  init_array(&anchors, 0);
+  int result = write_failed ? -1 : mmdoc_anchors(&anchors, path);
+  const char *expected[] = {"#page", "#example-anchor", "#lib-anchor",
+                            "#first-alias", "#second-alias"};
+  int passed = result == 0 && anchors.used == 5;
+  for (size_t i = 0; passed && i < 5; i++)
+    passed = strcmp(anchors.array[i], expected[i]) == 0;
+
+  free_array(&anchors);
+  unlink(path);
+  if (!passed) {
+    printf("AST anchor discovery test failed\n");
+    return 1;
+  }
+  printf("AST anchor discovery test passed\n");
   return 0;
 }
 
@@ -528,7 +570,7 @@ int test_multipage_shared_assets_and_accessible_controls() {
       file_contains(search_script_path, "window.mmdocSearchCorpus") &&
       file_contains(search_script_path, "limit: searchResultLimit");
   int page_is_accessible =
-      file_contains(index_path, "class='skip-link' href='#main-content'") &&
+      file_contains(index_path, "class='skip-link' href='./#main-content'") &&
       file_contains(index_path, "aria-controls='sidebar'") &&
       file_contains(index_path, "aria-label='Open search'") &&
       file_contains(index_path, "role='status' aria-live='polite'") &&
@@ -960,11 +1002,21 @@ int main(int argc, char *argv[]) {
   num_tests++;
   num_failed += test_render("e009");
   num_tests++;
+  num_failed += test_render("e013");
+  num_tests++;
+  num_failed += test_render("e014");
+  num_tests++;
+  num_failed += test_e015();
+  num_tests++;
+  num_failed += test_render("e016");
+  num_tests++;
   num_failed += test_copy_nested_image();
   num_tests++;
   num_failed += test_zero_capacity_arrays();
   num_tests++;
   num_failed += test_anchor_location_index();
+  num_tests++;
+  num_failed += test_anchor_discovery_uses_markdown_ast();
   num_tests++;
   num_failed += test_multipage_navigation_anchor();
   num_tests++;


### PR DESCRIPTION
## Summary

- discover anchors from the Markdown AST so code examples are not indexed as real targets
- render formatted span anchors and base-safe multipage fragment links
- generate valid definition lists, including compact definitions with multiple spaces after the colon
- add regression fixtures for the Nixpkgs manual cases

## Verification

- `nix develop -c meson test -C build --print-errorlogs`
- built the complete minman manual using this commit
- generated HTML audit: zero missing files, duplicate IDs, empty definition lists, raw span markup, or unresolved Python table placeholders for the selected fixes