### PR TITLE
Apply selected theme before first paint

### DIFF
--- a/src/asset/mmdoc.js
+++ b/src/asset/mmdoc.js
@@ -116,17 +116,23 @@ function getDefaultTheme() {
 
 // Returns 'light' or 'dark'
 function getSelectedTheme() {
-  return localStorage.getItem('theme') ?? getDefaultTheme()
+  let theme = null
+  try { theme = localStorage.getItem('theme') } catch (error) {}
+  return theme === 'light' || theme === 'dark' ? theme : getDefaultTheme()
+}
+
+function saveSelectedTheme(theme) {
+  try { localStorage.setItem('theme', theme) } catch (error) {}
 }
 
 function toggleTheme() {
   const theme = getSelectedTheme()
 
   if (theme === 'dark') {
-    localStorage.setItem('theme', 'light')
+    saveSelectedTheme('light')
     setLightTheme()
   } else if (theme === 'light') {
-    localStorage.setItem('theme', 'dark')
+    saveSelectedTheme('dark')
     setDarkTheme()
   }
 }

--- a/src/html.c
+++ b/src/html.c
@@ -2,6 +2,24 @@
 #include "html.h"
 #include "asset.h"
 
+int html_theme_init(FILE *file) {
+  return fputs("    <script>\n"
+               "      (() => {\n"
+               "        let theme = null\n"
+               "        try { theme = localStorage.getItem('theme') } catch "
+               "(error) {}\n"
+               "        if (theme !== 'light' && theme !== 'dark')\n"
+               "          theme = window.matchMedia('(prefers-color-scheme: "
+               "dark)').matches ? 'dark' : 'light'\n"
+               "        document.documentElement.classList.add(theme + "
+               "'-theme')\n"
+               "      })()\n"
+               "    </script>\n",
+               file) == EOF
+             ? -1
+             : 0;
+}
+
 int html_js(FILE *file) {
   fputs("<script>\n", file);
   if (asset_write_to_file_mmdoc_js(file) != 0)

--- a/src/html.h
+++ b/src/html.h
@@ -6,3 +6,4 @@
 int html_css(FILE *file);
 int html_highlight_js(FILE *file);
 int html_js(FILE *file);
+int html_theme_init(FILE *file);

--- a/src/multi.c
+++ b/src/multi.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: CC0-1.0 */
 #include "multi.h"
 #include "asset.h"
+#include "html.h"
 #include "render.h"
 #include <stdlib.h>
 #include <string.h>
@@ -119,9 +120,10 @@ int mmdoc_multi_page(Inputs inputs, AnchorLocationArray anchor_locations,
   fputs("'>\n"
         "    <meta charset='utf-8'>\n"
         "    <meta name='viewport' content='width=device-width, "
-        "initial-scale=1.0'>\n"
-        "    <meta name='description' content='",
+        "initial-scale=1.0'>\n",
         page_file);
+  html_theme_init(page_file);
+  fputs("    <meta name='description' content='", page_file);
   fputs(anchor_location->title, page_file);
   fputs("'>\n"
         "    <link rel='icon' href='favicon.svg'>\n",

--- a/src/single.c
+++ b/src/single.c
@@ -25,9 +25,10 @@ int mmdoc_single(Inputs inputs, AnchorLocationArray toc_anchor_locations) {
         "  <head>\n"
         "    <meta charset='utf-8'>\n"
         "    <meta name='viewport' content='width=device-width, "
-        "initial-scale=1.0'>\n"
-        "    <link rel='icon' href='favicon.svg'>\n",
+        "initial-scale=1.0'>\n",
         index_file);
+  html_theme_init(index_file);
+  fputs("    <link rel='icon' href='favicon.svg'>\n", index_file);
 
   html_css(index_file);
 

--- a/test/test.c
+++ b/test/test.c
@@ -414,6 +414,37 @@ int file_contains(char *path, const char *expected) {
   return found;
 }
 
+int file_contains_before(char *path, const char *first, const char *second) {
+  FILE *file = fopen(path, "r");
+  if (file == NULL)
+    return 0;
+
+  if (fseek(file, 0, SEEK_END) != 0) {
+    fclose(file);
+    return 0;
+  }
+  long file_size = ftell(file);
+  if (file_size < 0 || fseek(file, 0, SEEK_SET) != 0) {
+    fclose(file);
+    return 0;
+  }
+
+  char *contents = malloc((size_t)file_size + 1);
+  if (contents == NULL) {
+    fclose(file);
+    return 0;
+  }
+  size_t bytes_read = fread(contents, 1, (size_t)file_size, file);
+  contents[bytes_read] = '\0';
+  char *first_position = strstr(contents, first);
+  char *second_position = strstr(contents, second);
+  int found = first_position != NULL && second_position != NULL &&
+              first_position < second_position;
+  free(contents);
+  fclose(file);
+  return found;
+}
+
 int file_exists_and_is_not_empty(char *path) {
   FILE *file = fopen(path, "rb");
   if (file == NULL)
@@ -575,6 +606,12 @@ int test_multipage_shared_assets_and_accessible_controls() {
       file_contains(index_path, "aria-label='Open search'") &&
       file_contains(index_path, "role='status' aria-live='polite'") &&
       file_contains(index_path, "<main id='main-content' tabindex='-1'>");
+  int theme_is_initialized_before_css =
+      file_contains_before(index_path, "localStorage.getItem('theme')",
+                           generated_names.mmdoc_css) &&
+      file_contains(index_path,
+                    "document.documentElement.classList.add(theme + "
+                    "'-theme')");
 
   for (size_t i = 0; i < sizeof(asset_names) / sizeof(asset_names[0]); i++) {
     unlink_asset(root, asset_names[i]);
@@ -612,7 +649,8 @@ int test_multipage_shared_assets_and_accessible_controls() {
 
   if (render_result != 0 || no_code_render_result != 0 || !assets_found ||
       !names_are_hashed || !page_is_external || !page_is_accessible ||
-      !search_is_lazy || !corpus_hash_changed || !highlighter_is_conditional) {
+      !theme_is_initialized_before_css || !search_is_lazy ||
+      !corpus_hash_changed || !highlighter_is_conditional) {
     printf("multipage shared asset and accessibility test failed\n");
     return 1;
   }
@@ -646,6 +684,8 @@ int test_single_page_accessible_controls() {
                        file_contains(index_path, "aria-controls='sidebar'") &&
                        file_contains(index_path, "aria-pressed='false'") &&
                        file_contains(index_path, "id='main-content'");
+  int theme_is_initialized_before_css = file_contains_before(
+      index_path, "localStorage.getItem('theme')", "<style>");
 
   free_anchor_location_array(&toc_anchor_locations);
   unlink(index_path);
@@ -653,7 +693,8 @@ int test_single_page_accessible_controls() {
   rmdir(out_path);
   rmdir(root);
 
-  if (render_result != 0 || !controls_found) {
+  if (render_result != 0 || !controls_found ||
+      !theme_is_initialized_before_css) {
     printf("single-page accessibility test failed\n");
     return 1;
   }


### PR DESCRIPTION
## Summary

- add a small synchronous theme bootstrap in the document head before styles are loaded
- apply the persisted light or dark class before the browser's first paint
- use the system color preference when no valid stored preference exists
- handle unavailable local storage without breaking theme controls
- cover both multipage and single-page output ordering with regression tests

## Verification

- `nix develop -c meson test -C build --print-errorlogs`
- `nix build --no-link .#mmdoc`
- manually verified the generated multipage documentation while navigating in dark mode