### PR TITLE
Fix memory leaks during documentation generation

### DIFF
--- a/src/anchors.c
+++ b/src/anchors.c
@@ -11,13 +11,89 @@ int mmdoc_anchors(Array *md_anchors, char *path) {
   return mmdoc_render_collect_anchors(path, md_anchors);
 }
 
+static char *copy_string(const char *source) {
+  char *copy = malloc(strlen(source) + 1);
+  if (copy != NULL)
+    strcpy(copy, source);
+  return copy;
+}
+
+static int init_anchor_location(AnchorLocation *al, const char *anchor,
+                                const char *file_path, const char *title,
+                                const char *index_anchor, Inputs inputs) {
+  memset(al, 0, sizeof(*al));
+  al->anchor = copy_string(anchor);
+  al->file_path = copy_string(file_path);
+  al->title = copy_string(title);
+  if (al->anchor == NULL || al->file_path == NULL || al->title == NULL)
+    goto allocation_failed;
+
+  if (strcmp(al->anchor, index_anchor) == 0) {
+    const char *index_html = "index.html";
+    al->multipage_output_file_path =
+        malloc(strlen(inputs.out_multi) + 1 + strlen(index_html) + 1);
+    al->multipage_output_directory_path = copy_string(inputs.out_multi);
+    al->multipage_url = copy_string("./");
+    al->multipage_base_href = copy_string("");
+    if (al->multipage_output_file_path == NULL ||
+        al->multipage_output_directory_path == NULL ||
+        al->multipage_url == NULL || al->multipage_base_href == NULL)
+      goto allocation_failed;
+    sprintf(al->multipage_output_file_path, "%s/%s", inputs.out_multi,
+            index_html);
+    return 0;
+  }
+
+  char *page_path =
+      malloc(strlen(inputs.out_multi) + strlen(al->file_path) + 12);
+  if (page_path == NULL)
+    goto allocation_failed;
+  strcpy(page_path, inputs.out_multi);
+  strcat(page_path, al->file_path + strlen(inputs.src));
+  char *last_slash = strrchr(page_path, '/');
+  char *last_ext = strrchr(page_path, '.');
+  while (last_ext != NULL && (last_slash == NULL || last_ext > last_slash)) {
+    *last_ext = '\0';
+    last_ext = strrchr(page_path, '.');
+  }
+  strcat(page_path, "/");
+
+  al->multipage_output_directory_path = copy_string(page_path);
+  strcat(page_path, "index.html");
+  al->multipage_output_file_path = page_path;
+  if (al->multipage_output_directory_path == NULL)
+    goto allocation_failed;
+
+  al->multipage_url = copy_string(al->multipage_output_directory_path +
+                                  strlen(inputs.out_multi) + 1);
+  if (al->multipage_url == NULL)
+    goto allocation_failed;
+
+  size_t directory_depth = 0;
+  for (size_t i = 0; al->multipage_url[i] != '\0'; i++)
+    if (al->multipage_url[i] == '/')
+      directory_depth++;
+
+  al->multipage_base_href = malloc(3 * directory_depth + 1);
+  if (al->multipage_base_href == NULL)
+    goto allocation_failed;
+  al->multipage_base_href[0] = '\0';
+  for (size_t i = 0; i < directory_depth; i++)
+    strcat(al->multipage_base_href, "../");
+  return 0;
+
+allocation_failed:
+  fprintf(stderr, "Fatal: failed to allocate an anchor location.\n");
+  free_anchor_location(al);
+  return -1;
+}
+
 int mmdoc_anchors_locations(AnchorLocationArray *anchor_locations,
                             Array *md_files, Array *toc_refs, Inputs inputs) {
   char *index_anchor = toc_refs->array[0];
 
   init_anchor_location_array(anchor_locations, 500);
 
-  int count = 0;
   for (int i = 0; i < md_files->used; i++) {
     Array anchors;
     init_array(&anchors, 500);
@@ -28,75 +104,43 @@ int mmdoc_anchors_locations(AnchorLocationArray *anchor_locations,
     char *title = NULL;
     if (anchors.used > 0)
       title = mmdoc_render_get_title_from_file(md_files->array[i]);
+    if (anchors.used > 0 && title == NULL) {
+      fprintf(stderr, "Fatal: failed to read the title from %s.\n",
+              md_files->array[i]);
+      free_array(&anchors);
+      free_anchor_location_array_deep(anchor_locations);
+      return -1;
+    }
     for (int j = 0; j < anchors.used; j++) {
-      AnchorLocation *al = malloc(sizeof *al);
-      al->anchor = anchors.array[j];
-      al->file_path = md_files->array[i];
-
-      char *page_path =
-          malloc(strlen(inputs.out_multi) + strlen(al->file_path) + 12);
-      strcpy(page_path, inputs.out_multi);
-      strcat(page_path, al->file_path + strlen(inputs.src));
-      char *lastExt = strrchr(page_path, '.');
-      while (lastExt != NULL) {
-        *lastExt = '\0';
-        lastExt = strrchr(page_path, '.');
-        if (lastExt < strrchr(page_path, '/'))
-          break;
-      }
-      strcat(page_path, "/");
-      char *page_dir_path = malloc(strlen(page_path) + 1);
-      strcpy(page_dir_path, page_path);
-      strcat(page_path, "index.html");
-      al->multipage_output_file_path = page_path;
-      al->multipage_output_directory_path = page_dir_path;
-      al->multipage_url = page_dir_path + strlen(inputs.out_multi) + 1;
-
-      int directory_depth = 0;
-      for (int k = 0; k < strlen(al->multipage_url); k++)
-        if (al->multipage_url[k] == '/')
-          directory_depth++;
-
-      al->multipage_base_href = malloc(3 * directory_depth + 1);
-      strcpy(al->multipage_base_href, "");
-      for (int k = 0; k < directory_depth; k++)
-        strcat(al->multipage_base_href, "../");
-
-      al->title = malloc(strlen(title) + 1);
-      strcpy(al->title, title);
-
-      if (strcmp(al->anchor, index_anchor) == 0) {
-        char *index_html = "index.html";
-        char *index_file_path =
-            malloc(strlen(inputs.out_multi) + 1 + strlen(index_html) + 1);
-        sprintf(index_file_path, "%s/%s", inputs.out_multi, index_html);
-        al->multipage_output_file_path = index_file_path;
-        al->multipage_output_directory_path = inputs.out_multi;
-        al->multipage_url = "./";
-        al->multipage_base_href = "";
-      }
-
-      if (mkdir_p(al->multipage_output_directory_path) != 0) {
-        printf("Error recursively making directory %s",
-               al->multipage_output_directory_path);
+      AnchorLocation al;
+      if (init_anchor_location(&al, anchors.array[j], md_files->array[i], title,
+                               index_anchor, inputs) != 0) {
+        free(title);
+        free_array(&anchors);
+        free_anchor_location_array_deep(anchor_locations);
         return -1;
       }
 
-      int dash_count = 0;
-      for (int k = 0; *(al->file_path + strlen(inputs.src) + k) != '\0'; k++) {
-        char *c = al->file_path + strlen(inputs.src) + k;
-        if (c[0] == '/')
-          dash_count++;
-        if (c[0] == '-')
-          dash_count++;
+      if (mkdir_p(al.multipage_output_directory_path) != 0) {
+        printf("Error recursively making directory %s",
+               al.multipage_output_directory_path);
+        free_anchor_location(&al);
+        free(title);
+        free_array(&anchors);
+        free_anchor_location_array_deep(anchor_locations);
+        return -1;
       }
 
-      insert_anchor_location_array(anchor_locations, al);
-      count++;
+      insert_anchor_location_array(anchor_locations, &al);
     }
     free(title);
+    free_array(&anchors);
   }
-  return build_anchor_location_index(anchor_locations);
+  if (build_anchor_location_index(anchor_locations) != 0) {
+    free_anchor_location_array_deep(anchor_locations);
+    return -1;
+  }
+  return 0;
 }
 
 int mmdoc_anchors_find_toc_anchors(AnchorLocationArray *toc_anchor_locations,

--- a/src/inputs.c
+++ b/src/inputs.c
@@ -9,6 +9,9 @@ int mmdoc_inputs_derive(Inputs *inputs, char *argv[]) {
   inputs->project_name = argv[1];
   inputs->src = argv[2];
   inputs->out = argv[3];
+  inputs->toc_path = NULL;
+  inputs->out_multi = NULL;
+  inputs->out_single = NULL;
 
   char *src_relative_toc_path = "/toc.md";
   char *toc_path =
@@ -21,12 +24,19 @@ int mmdoc_inputs_derive(Inputs *inputs, char *argv[]) {
   strcat(toc_path, src_relative_toc_path);
   if (access(toc_path, F_OK) != 0) {
     printf("Expected but did not find: \"%s\"", toc_path);
+    free(toc_path);
     return -1;
   }
   inputs->toc_path = toc_path;
 
   char *multi = "multi";
   char *out_multi = malloc(strlen(inputs->out) + 1 + strlen(multi) + 1);
+  if (out_multi == NULL) {
+    fprintf(stderr,
+            "Fatal: failed to allocate memory for multi output path.\n");
+    mmdoc_inputs_free(inputs);
+    return -1;
+  }
   strcpy(out_multi, inputs->out);
   strcat(out_multi, "/");
   strcat(out_multi, multi);
@@ -34,10 +44,25 @@ int mmdoc_inputs_derive(Inputs *inputs, char *argv[]) {
 
   char *single = "single";
   char *out_single = malloc(strlen(inputs->out) + 1 + strlen(single) + 1);
+  if (out_single == NULL) {
+    fprintf(stderr,
+            "Fatal: failed to allocate memory for single output path.\n");
+    mmdoc_inputs_free(inputs);
+    return -1;
+  }
   strcpy(out_single, inputs->out);
   strcat(out_single, "/");
   strcat(out_single, single);
   inputs->out_single = out_single;
 
   return 0;
+}
+
+void mmdoc_inputs_free(Inputs *inputs) {
+  free(inputs->toc_path);
+  free(inputs->out_multi);
+  free(inputs->out_single);
+  inputs->toc_path = NULL;
+  inputs->out_multi = NULL;
+  inputs->out_single = NULL;
 }

--- a/src/inputs.h
+++ b/src/inputs.h
@@ -11,3 +11,4 @@ typedef struct {
 } Inputs;
 
 int mmdoc_inputs_derive(Inputs *inputs, char *argv[]);
+void mmdoc_inputs_free(Inputs *inputs);

--- a/src/mmdoc.c
+++ b/src/mmdoc.c
@@ -35,41 +35,48 @@ int main(int argc, char *argv[]) {
     print_usage();
     return 1;
   }
-  Inputs inputs;
+  int result = 1;
+  Inputs inputs = {0};
+  Array toc_refs = {0};
+  Array md_files = {0};
+  AnchorLocationArray anchor_locations = {0};
+  AnchorLocationArray toc_anchor_locations = {0};
+
   if (0 != mmdoc_inputs_derive(&inputs, argv))
-    return 1;
+    goto cleanup;
 
-  Array toc_refs;
   if (0 != mmdoc_refs(&toc_refs, inputs.toc_path))
-    return 1;
+    goto cleanup;
 
-  Array md_files;
   init_array(&md_files, 100);
   mmdoc_md_files(&md_files, inputs.src);
 
-  AnchorLocationArray anchor_locations;
   if (0 !=
       mmdoc_anchors_locations(&anchor_locations, &md_files, &toc_refs, inputs))
-    return 1;
+    goto cleanup;
 
-  AnchorLocationArray toc_anchor_locations;
   init_anchor_location_array(&toc_anchor_locations, toc_refs.used);
   if (0 != mmdoc_anchors_find_toc_anchors(&toc_anchor_locations, &toc_refs,
                                           &anchor_locations))
-    return 1;
+    goto cleanup;
   free_array(&toc_refs);
 
   if (0 != mmdoc_single(inputs, toc_anchor_locations))
-    return 1;
+    goto cleanup;
 
   if (0 != mmdoc_multi(inputs, toc_anchor_locations, anchor_locations))
-    return 1;
+    goto cleanup;
 
   if (0 != copy_imgs(inputs))
-    return 1;
+    goto cleanup;
 
+  result = 0;
+
+cleanup:
+  free_array(&toc_refs);
   free_array(&md_files);
   free_anchor_location_array(&toc_anchor_locations);
-  free_anchor_location_array(&anchor_locations);
-  return 0;
+  free_anchor_location_array_deep(&anchor_locations);
+  mmdoc_inputs_free(&inputs);
+  return result;
 }

--- a/src/render.c
+++ b/src/render.c
@@ -77,6 +77,7 @@ int replace_header_attributes(cmark_node *node, char *input_file_path,
     new_lit[i] = '\0';
     cmark_node *new_node = cmark_node_new(CMARK_NODE_TEXT);
     cmark_node_set_literal(new_node, new_lit);
+    free(new_lit);
     cmark_node_replace(last_child, new_node);
   }
 
@@ -113,6 +114,8 @@ int replace_headers_with_attributes_for_html(char *multipage_url,
   cmark_node *new_node = cmark_node_new(CMARK_NODE_CUSTOM_BLOCK);
   cmark_node_set_on_enter(new_node, on_enter);
   cmark_node_set_on_exit(new_node, on_exit);
+  free(on_enter);
+  free(on_exit);
   cmark_node_replace_with_children(node, new_node);
 
   free(info->anchor);

--- a/src/types.c
+++ b/src/types.c
@@ -83,6 +83,17 @@ AnchorLocation *find_anchor_location(AnchorLocationArray *a,
   return NULL;
 }
 
+void free_anchor_location(AnchorLocation *location) {
+  free(location->file_path);
+  free(location->multipage_output_file_path);
+  free(location->multipage_output_directory_path);
+  free(location->multipage_url);
+  free(location->multipage_base_href);
+  free(location->anchor);
+  free(location->title);
+  memset(location, 0, sizeof(*location));
+}
+
 void free_anchor_location_array(AnchorLocationArray *a) {
   free(a->anchor_index);
   free(a->array);
@@ -90,6 +101,12 @@ void free_anchor_location_array(AnchorLocationArray *a) {
   a->anchor_index = NULL;
   a->anchor_index_size = 0;
   a->used = a->size = 0;
+}
+
+void free_anchor_location_array_deep(AnchorLocationArray *a) {
+  for (size_t i = 0; i < a->used; i++)
+    free_anchor_location(&a->array[i]);
+  free_anchor_location_array(a);
 }
 
 void init_array(Array *a, size_t initialSize) {

--- a/src/types.h
+++ b/src/types.h
@@ -36,7 +36,9 @@ void insert_anchor_location_array(AnchorLocationArray *a,
 int build_anchor_location_index(AnchorLocationArray *a);
 AnchorLocation *find_anchor_location(AnchorLocationArray *a,
                                      const char *anchor);
+void free_anchor_location(AnchorLocation *location);
 void free_anchor_location_array(AnchorLocationArray *a);
+void free_anchor_location_array_deep(AnchorLocationArray *a);
 void init_array(Array *a, size_t initialSize);
 void insert_array(Array *a, char *element);
 void free_array(Array *a);


### PR DESCRIPTION
## Summary

- give generated anchor locations explicit ownership and deep cleanup
- release derived input paths and temporary cmark rendering buffers
- use a unified cleanup path for successful and failed generation

## Verification

- nix develop -c meson test -C build --print-errorlogs
- nix build .#mmdoc --no-link -L
- generated the ryantm/nixpkgs minman manual under Valgrind 3.27.1
- Valgrind: 0 bytes definitely, indirectly, or possibly lost; 0 errors